### PR TITLE
Configure Vercel for /api/solution endpoint

### DIFF
--- a/api/solution.ts
+++ b/api/solution.ts
@@ -1,0 +1,1 @@
+export { default } from '../backend/src/routes/solution';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "vercel-build": "cd backend && npm run build"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "backend/src/routes/solution.ts",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/api/solution",
+      "dest": "backend/src/routes/solution.ts"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` to deploy the backend `solution` route with `@vercel/node`
- expose backend handler through `api/solution.ts`
- add `vercel-build` script for Vercel

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688a339ba790832793433b1cb317694c