### PR TITLE
Implement conversation storage and agent logging API

### DIFF
--- a/backend/src/routes/agent.ts
+++ b/backend/src/routes/agent.ts
@@ -1,0 +1,26 @@
+import { Router } from "express";
+import crypto from "node:crypto";
+import storage, { Turn } from "../utils/storage";
+
+const router = Router();
+
+router.post("/", async (req, res) => {
+  const {
+    conversationId = crypto.randomUUID(),
+    role,
+    text,
+    phase,
+    mode,
+    language,
+  } = req.body;
+
+  const turn: Turn & { mode?: string } = { role, text, t: Date.now(), phase };
+
+  await storage.appendTurn(conversationId, turn);
+
+  await storage.updateConversation(conversationId, { phase, mode, language });
+
+  res.status(200).json({ conversationId });
+});
+
+export default router;

--- a/backend/src/utils/storage.ts
+++ b/backend/src/utils/storage.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export interface Turn {
+  role: "user" | "assistant" | "tool";
+  text: string;
+  t: number;
+  phase?: Conversation["phase"];
+}
+
+export interface Conversation {
+  id: string;
+  createdAt: string;
+  language?: "hr" | "en";
+  phase: "intro" | "collect" | "closing" | "ended";
+  mode: "voice" | "chat";
+  turns: Turn[];
+  solution?: { solutionText: string; cta: string };
+  contact?: { email?: string; phone?: string };
+  ended?: boolean;
+}
+
+const DIR = path.join(process.cwd(), "backend", "transcripts");
+
+async function readConversation(file: string, id: string): Promise<Conversation> {
+  try {
+    const data = await fs.readFile(file, "utf-8");
+    return JSON.parse(data) as Conversation;
+  } catch {
+    return {
+      id,
+      createdAt: new Date().toISOString(),
+      phase: "intro",
+      mode: "chat",
+      turns: [],
+    };
+  }
+}
+
+async function writeConversation(file: string, convo: Conversation) {
+  await fs.mkdir(DIR, { recursive: true });
+  await fs.writeFile(file, JSON.stringify(convo, null, 2), "utf-8");
+}
+
+async function appendTurn(
+  conversationId: string,
+  turn: Turn & { mode?: Conversation["mode"] }
+) {
+  const file = path.join(DIR, `${conversationId}.json`);
+  const convo = await readConversation(file, conversationId);
+  convo.turns.push(turn);
+  if (turn.phase) {
+    convo.phase = turn.phase;
+  }
+  if (turn.mode) {
+    convo.mode = turn.mode;
+  }
+  await writeConversation(file, convo);
+}
+
+async function updateConversation(
+  conversationId: string,
+  patch: Partial<Conversation>
+) {
+  const file = path.join(DIR, `${conversationId}.json`);
+  const convo = await readConversation(file, conversationId);
+  Object.assign(convo, patch);
+  await writeConversation(file, convo);
+}
+
+async function getConversation(
+  conversationId: string
+): Promise<Conversation | null> {
+  const file = path.join(DIR, `${conversationId}.json`);
+  try {
+    const data = await fs.readFile(file, "utf-8");
+    return JSON.parse(data) as Conversation;
+  } catch {
+    return null;
+  }
+}
+
+export default { appendTurn, updateConversation, getConversation };


### PR DESCRIPTION
## Summary
- add persistent conversation storage utility
- create `/api/agent` route to log dialog turns

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a4032ab00832790c71664e9ad24a3