### PR TITLE
Implement ElevenLabs TTS proxy

### DIFF
--- a/backend/src/routes/tts.ts
+++ b/backend/src/routes/tts.ts
@@ -1,0 +1,50 @@
+import { Router } from "express";
+
+// Router for ElevenLabs text-to-speech proxy
+const router = Router();
+
+router.post('/', async (req, res) => {
+  const { text, voiceId = process.env.ELEVENLABS_VOICE_ID, modelId = 'eleven_multilingual_v2' } = req.body as {
+    text?: string;
+    voiceId?: string;
+    modelId?: string;
+  };
+
+  if (!text) {
+    res.status(400).json({ error: 'Missing text' });
+    return;
+  }
+
+  try {
+    const apiRes = await fetch(
+      `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}/stream`,
+      {
+        method: 'POST',
+        headers: {
+          'xi-api-key': process.env.ELEVENLABS_API_KEY ?? '',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          text,
+          model_id: modelId,
+          voice_settings: { similarity_boost: 0.5, stability: 0.35 },
+        }),
+      }
+    );
+
+    if (!apiRes.ok) {
+      const data = await apiRes.json().catch(() => ({}));
+      res.status(apiRes.status).json({ error: data.error || data.message });
+      return;
+    }
+
+    // Propagate status and headers then pipe stream to client
+    res.status(apiRes.status);
+    res.setHeader('Content-Type', apiRes.headers.get('Content-Type') || 'audio/mpeg');
+    apiRes.body?.pipe(res);
+  } catch (err) {
+    res.status(500).json({ error: 'TTS request failed' });
+  }
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,10 +1,14 @@
 import express from 'express';
 import agentRouter from './routes/agent';
+// Import the ElevenLabs TTS proxy router
+import ttsRouter from './routes/tts';
 
 const app = express();
 
 app.use(express.json());
 
 app.use('/api/agent', agentRouter);
+// Mount the TTS proxy under /api/tts
+app.use('/api/tts', ttsRouter);
 
 export default app;


### PR DESCRIPTION
## Summary
- add new `/api/tts` router that proxies requests to ElevenLabs TTS API
- register new router in the backend server

## Testing
- `npm --prefix backend run build` *(fails: Could not find a declaration file for module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688a4788ab1c832794c30afc0564d9c3