### PR TITLE
Add ElevenLabs chat proxy

### DIFF
--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -1,0 +1,56 @@
+import { Router } from "express";
+import { appendTurn } from "../utils/storage";
+
+const router = Router();
+
+/**
+ * Proxy to ElevenLabs Conversation text endpoint.
+ */
+router.post('/', async (req, res) => {
+  const { conversationId, text } = req.body as {
+    conversationId: string;
+    text: string;
+    language?: 'hr' | 'en';
+  };
+
+  if (!conversationId || !text) {
+    res.status(400).json({ error: 'Missing conversationId or text' });
+    return;
+  }
+
+  try {
+    const apiRes = await fetch('https://api.elevenlabs.io/v1/conversation', {
+      method: 'POST',
+      headers: {
+        'xi-api-key': process.env.ELEVENLABS_API_KEY ?? '',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        conversation_id: conversationId,
+        text,
+        model_id: 'eleven_multilingual_v2',
+      }),
+    });
+
+    if (!apiRes.ok) {
+      const data = await apiRes.json().catch(() => ({}));
+      res.status(apiRes.status).json({ error: data.error || data.message });
+      return;
+    }
+
+    const data = (await apiRes.json()) as { reply: string };
+    const reply = data.reply;
+
+    await appendTurn(conversationId, {
+      role: 'assistant',
+      text: reply,
+      mode: 'chat',
+    });
+
+    res.json({ reply });
+  } catch (err) {
+    res.status(500).json({ error: 'Chat request failed' });
+  }
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import agentRouter from './routes/agent';
 // Import the ElevenLabs TTS proxy router
 import ttsRouter from './routes/tts';
+import chatRouter from './routes/chat';
 
 const app = express();
 
@@ -10,5 +11,6 @@ app.use(express.json());
 app.use('/api/agent', agentRouter);
 // Mount the TTS proxy under /api/tts
 app.use('/api/tts', ttsRouter);
+app.use('/api/chat', chatRouter);
 
 export default app;


### PR DESCRIPTION
## Summary
- implement `/api/chat` route to proxy ElevenLabs conversation API
- hook up the chat router in `server.ts`

## Testing
- `npm --prefix backend run build` *(fails: Could not find @types/express)*

------
https://chatgpt.com/codex/tasks/task_e_688a624e57a483279a488762354ca869