### PR TITLE
Add GDPR consent modal

### DIFF
--- a/src/components/GdprModal.tsx
+++ b/src/components/GdprModal.tsx
@@ -1,0 +1,45 @@
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useState } from "react";
+
+interface Props {
+  open: boolean;
+  onAccept: () => void;
+  onClose: () => void;
+}
+
+export default function GdprModal({ open, onAccept, onClose }: Props) {
+  const [checked, setChecked] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Privola za snimanje razgovora</DialogTitle>
+        </DialogHeader>
+
+        <p className="text-sm leading-relaxed">
+          Razgovor se snima i pohranjuje isključivo radi pružanja AI savjetovanja.
+          Više detalja možete pronaći u našoj{" "}
+          <a href="#privatnost" className="underline text-primary">
+            politici privatnosti
+          </a>.
+        </p>
+
+        <div className="flex items-center space-x-2 pt-4">
+          <Checkbox id="consent" checked={checked} onCheckedChange={v => setChecked(!!v)} />
+          <label htmlFor="consent" className="text-sm select-none">
+            Prihvaćam snimanje razgovora
+          </label>
+        </div>
+
+        <DialogFooter>
+          <Button onClick={onAccept} disabled={!checked}>
+            Prihvaćam
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- create `GdprModal` component with shadcn dialog
- integrate consent modal into `AgentPanel` with local storage tracking
- log consent acceptance to backend

## Testing
- `npm run dev` *(builds without TypeScript errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a6ccc29f08327b5d1f36e68ecfac2