### PR TITLE
Remove demo placeholders and update backend start

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,10 +1,11 @@
 {
   "name": "backend",
   "version": "1.0.0",
-  "type": "module",
   "main": "dist/server.js",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "ts-node-dev --respawn src/server.ts"
   },
   "dependencies": {
     "express": "^4.18.2"

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,3 +1,4 @@
+require("dotenv").config();
 import express from 'express';
 import agentRouter from './routes/agent';
 // Import the ElevenLabs TTS proxy router

--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -42,13 +42,7 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
       mute: "Mute",
       privacy: "Razgovor se snima i transkribira u produkciji. Ovo je demo bez snimanja.",
       learnMore: "Saznaj više",
-      steps: ["Uvod", "Pitanja", "Rješenje"],
-      demoMessages: [
-        "Bok! Primjer 1: AI može automatski izraditi ponudu iz e‑mail upita.",
-        "Primjer 2: Sažimanje računa u tablicu bez ručnog pretipkavanja.",
-        "Koje su najveće repetitivne zadatke u vašoj tvrtki?",
-        "Koristite li već neke automatizacije u poslovanju?"
-      ]
+      steps: ["Uvod", "Pitanja", "Rješenje"]
     },
     en: {
       title: "ONE AI solution for your company in 90 seconds.",
@@ -58,13 +52,7 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
       mute: "Mute",
       privacy: "Conversation is recorded and transcribed in production. This is a demo without recording.",
       learnMore: "Learn more",
-      steps: ["Intro", "Questions", "Solution"],
-      demoMessages: [
-        "Hello! Example 1: AI can automatically create quotes from email inquiries.",
-        "Example 2: Summarizing invoices into tables without manual retyping.",
-        "What are the biggest repetitive tasks in your company?",
-        "Do you already use any automation in your business?"
-      ]
+      steps: ["Intro", "Questions", "Solution"]
     }
   } as const;
 
@@ -75,23 +63,10 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
       setCurrentStep(prev => (prev + 1) % 3);
     }, 5000);
 
-    const messageInterval = setInterval(() => {
-      setMessages(prev => {
-        if (prev.length >= currentTexts.demoMessages.length) return prev;
-        const newMessage = {
-          type: "agent" as const,
-          text: currentTexts.demoMessages[prev.length],
-          time: new Date().toLocaleTimeString("hr-HR", { hour: "2-digit", minute: "2-digit" })
-        };
-        return [...prev, newMessage];
-      });
-    }, 3000);
-
     return () => {
       clearInterval(interval);
-      clearInterval(messageInterval);
     };
-  }, [currentTexts.demoMessages]);
+  }, []);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });


### PR DESCRIPTION
## Summary
- remove demo interval messages in `AgentPanel`
- adjust backend scripts and drop ESM flag
- load env vars when backend starts

## Testing
- `npm run lint` *(fails: `@typescript-eslint` errors)*
- `npm run build`
- `npm --prefix backend run build` *(fails: cannot find module 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_688a9427e5448327bd5e845d18273603