### PR TITLE
Add server entrypoint

### DIFF
--- a/backend/dist/index.js
+++ b/backend/dist/index.js
@@ -1,0 +1,10 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const server_1 = __importDefault(require("./server"));
+const port = process.env.PORT || 3000;
+server_1.default.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,11 +1,11 @@
 {
   "name": "backend",
   "version": "1.0.0",
-  "main": "dist/server.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/server.js",
-    "dev": "ts-node-dev --respawn src/server.ts"
+    "start": "node dist/index.js",
+    "dev": "ts-node-dev --respawn src/index.ts"
   },
   "dependencies": {
     "dotenv": "^17.2.1",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,7 @@
+import app from './server';
+
+const port = process.env.PORT || 3000;
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add backend/src/index.ts to start the Express server
- adjust backend/package.json scripts to use the new entry file
- include compiled dist/index.js

## Testing
- `npm run build` in backend
- `npm run dev` in backend

------
https://chatgpt.com/codex/tasks/task_e_688aa65b733483279070f8b7a2681c74