### PR TITLE
Add request logging middleware

### DIFF
--- a/backend/dist/server.js
+++ b/backend/dist/server.js
@@ -13,6 +13,11 @@ const transcripts_1 = __importDefault(require("./routes/transcripts"));
 const solution_1 = __importDefault(require("./routes/solution"));
 const app = (0, express_1.default)();
 app.use(express_1.default.json());
+// Logging middleware for debugging purposes
+app.use((req, _res, next) => {
+    console.log(req.method, req.originalUrl, req.body);
+    next();
+});
 app.use('/api/agent', agent_1.default);
 // Mount the TTS proxy under /api/tts
 app.use('/api/tts', tts_1.default);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,5 +1,5 @@
 require("dotenv").config();
-import express from 'express';
+import express, { type Request, type Response, type NextFunction } from 'express';
 import agentRouter from './routes/agent';
 // Import the ElevenLabs TTS proxy router
 import ttsRouter from './routes/tts';
@@ -10,6 +10,11 @@ import solutionRouter from './routes/solution';
 const app = express();
 
 app.use(express.json());
+// Logging middleware for debugging purposes
+app.use((req: Request, _res: Response, next: NextFunction) => {
+  console.log(req.method, req.originalUrl, req.body);
+  next();
+});
 
 app.use('/api/agent', agentRouter);
 // Mount the TTS proxy under /api/tts


### PR DESCRIPTION
## Summary
- log incoming requests in the backend server
- rebuild backend

## Testing
- `npm run build` in `backend`
- `npm start` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_688aa65c63d483279697681870e1bd49