### PR TITLE
Fix proxy port for dev API

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,9 +16,11 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "localhost",
     port: 5173,
+    // Proxy API requests during development to the Express backend
     proxy: {
       "/api": {
-        target: "http://localhost:8080",
+        // Ensure calls are forwarded to the backend listening on port 3000
+        target: "http://localhost:3000",
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
## Summary
- update Vite proxy so `/api` points to the Express backend running on port 3000

## Testing
- `npm run lint` *(fails: Unexpected any, no-require-imports, etc.)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688ab4df166c83279e03a1e7d025249e