### PR TITLE
Fix STT proxy to use header API key

### DIFF
--- a/backend/dist/sttProxy.js
+++ b/backend/dist/sttProxy.js
@@ -1,0 +1,32 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.attachSttProxy = attachSttProxy;
+const ws_1 = require("ws");
+function attachSttProxy(server) {
+    const wss = new ws_1.WebSocketServer({ noServer: true });
+    server.on('upgrade', (req, socket, head) => {
+        if (req.url !== '/api/stt')
+            return;
+        wss.handleUpgrade(req, socket, head, (client) => {
+            const upstream = new ws_1.WebSocket('wss://api.elevenlabs.io/v1/speech-to-text/ws', undefined, { headers: { 'xi-api-key': process.env.ELEVENLABS_API_KEY ?? '' } });
+            client.on('message', (msg) => {
+                if (upstream.readyState === ws_1.WebSocket.OPEN) {
+                    upstream.send(msg);
+                }
+            });
+            upstream.on('message', (msg) => {
+                if (client.readyState === ws_1.WebSocket.OPEN) {
+                    client.send(msg);
+                }
+            });
+            const closeBoth = () => {
+                if (client.readyState === ws_1.WebSocket.OPEN)
+                    client.close();
+                if (upstream.readyState === ws_1.WebSocket.OPEN)
+                    upstream.close();
+            };
+            client.on('close', closeBoth);
+            upstream.on('close', closeBoth);
+        });
+    });
+}

--- a/backend/src/sttProxy.ts
+++ b/backend/src/sttProxy.ts
@@ -8,10 +8,11 @@ export function attachSttProxy(server: HTTPServer) {
   server.on('upgrade', (req: IncomingMessage, socket: Socket, head: Buffer) => {
     if (req.url !== '/api/stt') return;
     wss.handleUpgrade(req, socket, head, (client: WebSocket) => {
-      const upstream = new WebSocket('wss://api.elevenlabs.io/v1/speech-to-text/ws', [
-        'xi-api-key',
-        process.env.ELEVENLABS_API_KEY || ''
-      ]);
+      const upstream = new WebSocket(
+        'wss://api.elevenlabs.io/v1/speech-to-text/ws',
+        undefined,
+        { headers: { 'xi-api-key': process.env.ELEVENLABS_API_KEY ?? '' } }
+      );
 
       client.on('message', (msg: RawData) => {
         if (upstream.readyState === WebSocket.OPEN) {

--- a/backend/src/ws.d.ts
+++ b/backend/src/ws.d.ts
@@ -3,7 +3,7 @@ declare module 'ws' {
 
   export class WebSocket {
     static OPEN: number;
-    constructor(address: string, protocols?: string | string[]);
+    constructor(address: string, protocols?: string | string[], options?: any);
     readyState: number;
     send(data: RawData): void;
     close(code?: number, reason?: string): void;


### PR DESCRIPTION
## Summary
- send ElevenLabs API key via header instead of subprotocol
- update local ws.d.ts declaration to allow options object
- rebuild backend to include new sttProxy.js

## Testing
- `npm run build` in `backend`
- `npm start` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_688b4600e24c83278797e7e78712792c