### PR TITLE
Fix transcripts parsing error

### DIFF
--- a/backend/dist/routes/transcripts.js
+++ b/backend/dist/routes/transcripts.js
@@ -16,7 +16,7 @@ router.use((req, res, next) => {
 });
 // GET /api/transcripts  → list
 router.get("/", async (_req, res) => {
-    const files = await promises_1.default.readdir(DIR);
+    const files = (await promises_1.default.readdir(DIR)).filter(f => f.endsWith(".json"));
     const data = await Promise.all(files.map(async (f) => {
         const json = JSON.parse(await promises_1.default.readFile(node_path_1.default.join(DIR, f), "utf8"));
         return {

--- a/backend/src/routes/transcripts.ts
+++ b/backend/src/routes/transcripts.ts
@@ -13,7 +13,7 @@ router.use((req: Request, res: Response, next: NextFunction) => {
 
 // GET /api/transcripts  → list
 router.get("/", async (_req: Request, res: Response) => {
-  const files = await fs.readdir(DIR);
+  const files = (await fs.readdir(DIR)).filter(f => f.endsWith(".json"));
   const data = await Promise.all(
     files.map(async f => {
       const json = JSON.parse(await fs.readFile(path.join(DIR, f), "utf8"));


### PR DESCRIPTION
## Summary
- skip non-JSON files when listing transcripts

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: could not find declaration files)*

------
https://chatgpt.com/codex/tasks/task_e_688b69ddc07c8327a8d93eb72a05a2ff