### PR TITLE
Implement summary and solution flow

### DIFF
--- a/backend/dist/routes/summary.js
+++ b/backend/dist/routes/summary.js
@@ -1,0 +1,24 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = require("express");
+const storage_1 = require("../utils/storage");
+const llm_1 = require("../utils/llm");
+const router = (0, express_1.Router)();
+router.post("/", async (req, res) => {
+    const { transcript, language } = req.body;
+    const conversationId = req.headers["x-conversation-id"] || "unknown";
+    if (!transcript) {
+        res.status(400).json({ error: "Missing transcript" });
+        return;
+    }
+    try {
+        const summary = await (0, llm_1.summarizeConversation)(transcript, language);
+        await (0, storage_1.appendTurn)(conversationId, { role: "tool", text: `[SUMMARY] ${summary}` });
+        res.json({ summary });
+    }
+    catch (err) {
+        console.error(err);
+        res.status(500).json({ error: "summary_failed" });
+    }
+});
+exports.default = router;

--- a/backend/dist/server.js
+++ b/backend/dist/server.js
@@ -8,9 +8,11 @@ const express_1 = __importDefault(require("express"));
 const agent_1 = __importDefault(require("./routes/agent"));
 // Import the ElevenLabs TTS proxy router
 const tts_1 = __importDefault(require("./routes/tts"));
+const evi_1 = __importDefault(require("./routes/evi"));
 const chat_1 = __importDefault(require("./routes/chat"));
 const transcripts_1 = __importDefault(require("./routes/transcripts"));
 const solution_1 = __importDefault(require("./routes/solution"));
+const summary_1 = __importDefault(require("./routes/summary"));
 const app = (0, express_1.default)();
 app.use(express_1.default.json());
 // Logging middleware for debugging purposes
@@ -21,7 +23,9 @@ app.use((req, _res, next) => {
 app.use('/api/agent', agent_1.default);
 // Mount the TTS proxy under /api/tts
 app.use('/api/tts', tts_1.default);
+app.use('/api/evi', evi_1.default);
 app.use('/api/chat', chat_1.default);
 app.use('/api/transcripts', transcripts_1.default);
 app.use('/api/solution', solution_1.default);
+app.use('/api/summary', summary_1.default);
 exports.default = app;

--- a/backend/dist/utils/llm.js
+++ b/backend/dist/utils/llm.js
@@ -5,6 +5,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getSolution = getSolution;
+exports.summarizeConversation = summarizeConversation;
 require("dotenv/config");
 const openai_1 = __importDefault(require("openai"));
 const openai = new openai_1.default({
@@ -39,4 +40,14 @@ Return plain text only.`;
             ? "Nazovite nas na +385 1 XXX XXX ili napišite 'DA' pa vas zovemo."
             : "Call us at +385 1 XXX XXX or reply 'YES' and we'll call you.",
     };
+}
+async function summarizeConversation(transcript, lang) {
+    const prompt = lang === "hr"
+        ? `Sažmi sljedeći razgovor u 2-3 kratke rečenice na hrvatskom jeziku:\n${transcript}`
+        : `Summarize the following conversation in 2-3 short sentences:\n${transcript}`;
+    const res = await openai.chat.completions.create({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: prompt }],
+    });
+    return res.choices[0].message.content?.trim() || "";
 }

--- a/backend/src/routes/summary.ts
+++ b/backend/src/routes/summary.ts
@@ -1,0 +1,26 @@
+import { Router, Request, Response } from "express";
+import { appendTurn } from "../utils/storage";
+import { summarizeConversation } from "../utils/llm";
+
+const router = Router();
+
+router.post("/", async (req: Request, res: Response) => {
+  const { transcript, language } = req.body as { transcript: string; language: "hr" | "en" };
+  const conversationId = (req.headers["x-conversation-id"] as string) || "unknown";
+
+  if (!transcript) {
+    res.status(400).json({ error: "Missing transcript" });
+    return;
+  }
+
+  try {
+    const summary = await summarizeConversation(transcript, language);
+    await appendTurn(conversationId, { role: "tool", text: `[SUMMARY] ${summary}` });
+    res.json({ summary });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "summary_failed" });
+  }
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -7,6 +7,7 @@ import eviRouter from './routes/evi';
 import chatRouter from './routes/chat';
 import transcriptsRouter from './routes/transcripts';
 import solutionRouter from './routes/solution';
+import summaryRouter from './routes/summary';
 
 const app = express();
 
@@ -24,5 +25,6 @@ app.use('/api/evi', eviRouter);
 app.use('/api/chat', chatRouter);
 app.use('/api/transcripts', transcriptsRouter);
 app.use('/api/solution', solutionRouter);
+app.use('/api/summary', summaryRouter);
 
 export default app;

--- a/backend/src/utils/llm.ts
+++ b/backend/src/utils/llm.ts
@@ -44,3 +44,15 @@ Return plain text only.`;
         : "Call us at +385 1 XXX XXX or reply 'YES' and we'll call you.",
   };
 }
+
+export async function summarizeConversation(transcript: string, lang: "hr" | "en"): Promise<string> {
+  const prompt =
+    lang === "hr"
+      ? `Sažmi sljedeći razgovor u 2-3 kratke rečenice na hrvatskom jeziku:\n${transcript}`
+      : `Summarize the following conversation in 2-3 short sentences:\n${transcript}`;
+  const res = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    messages: [{ role: "user", content: prompt }],
+  });
+  return res.choices[0].message.content?.trim() || "";
+}


### PR DESCRIPTION
## Summary
- add backend summary route and utilities
- include summary route in server
- enhance agent with real STT and closing flow for summary/solution

## Testing
- `npm run lint` *(fails: several lint errors in existing code)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688b6a934d208327bfeebd6c04063930