### PR TITLE
Add EVI websocket proxy

### DIFF
--- a/backend/dist/eviProxy.js
+++ b/backend/dist/eviProxy.js
@@ -1,0 +1,47 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.attachEviProxy = attachEviProxy;
+const ws_1 = require("ws");
+const hume_1 = require("hume");
+function attachEviProxy(server) {
+    const wss = new ws_1.WebSocketServer({ noServer: true });
+    server.on('upgrade', (req, socket, head) => {
+        if (req.url !== '/api/evi')
+            return;
+        wss.handleUpgrade(req, socket, head, (client) => {
+            (async () => {
+                const hume = new hume_1.HumeClient({
+                    apiKey: process.env.HUME_API_KEY ?? '',
+                    secretKey: process.env.HUME_SECRET_KEY ?? ''
+                });
+                const upstream = await hume.empathicVoice.chat.connect();
+                client.on('message', (msg) => {
+                    const text = typeof msg === 'string' ? msg : msg.toString();
+                    upstream.sendUserInput(text);
+                });
+                upstream.on('message', (msg) => {
+                    try {
+                        const data = JSON.parse(msg.toString());
+                        if (data.audio_output?.data) {
+                            const buf = Buffer.from(data.audio_output.data, 'base64');
+                            if (client.readyState === ws_1.WebSocket.OPEN) {
+                                client.send(buf);
+                            }
+                        }
+                    }
+                    catch { }
+                });
+                const closeBoth = () => {
+                    if (client.readyState === ws_1.WebSocket.OPEN)
+                        client.close();
+                    upstream.close();
+                };
+                client.on('close', closeBoth);
+                upstream.on('close', closeBoth);
+            })().catch(() => {
+                if (client.readyState === ws_1.WebSocket.OPEN)
+                    client.close();
+            });
+        });
+    });
+}

--- a/backend/dist/index.js
+++ b/backend/dist/index.js
@@ -6,8 +6,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const http_1 = __importDefault(require("http"));
 const server_1 = __importDefault(require("./server"));
 const sttProxy_1 = require("./sttProxy");
+const eviProxy_1 = require("./eviProxy");
 const server = http_1.default.createServer(server_1.default);
 (0, sttProxy_1.attachSttProxy)(server);
+(0, eviProxy_1.attachEviProxy)(server);
 server.listen(3000, () => {
     console.log('✅ Backend listening on http://localhost:3000');
 });

--- a/backend/src/eviProxy.ts
+++ b/backend/src/eviProxy.ts
@@ -1,0 +1,48 @@
+import { Server as HTTPServer, IncomingMessage } from 'http';
+import { Socket } from 'net';
+import { WebSocketServer, WebSocket, RawData } from 'ws';
+import { HumeClient } from 'hume';
+
+export function attachEviProxy(server: HTTPServer) {
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on('upgrade', (req: IncomingMessage, socket: Socket, head: Buffer) => {
+    if (req.url !== '/api/evi') return;
+    wss.handleUpgrade(req, socket, head, (client: WebSocket) => {
+      (async () => {
+        const hume = new HumeClient({
+          apiKey: process.env.HUME_API_KEY ?? '',
+          secretKey: process.env.HUME_SECRET_KEY ?? ''
+        });
+        const upstream = await hume.empathicVoice.chat.connect();
+
+        client.on('message', (msg: RawData) => {
+          const text = typeof msg === 'string' ? msg : msg.toString();
+          upstream.sendUserInput(text);
+        });
+
+        upstream.on('message', (msg: any) => {
+          try {
+            const data = JSON.parse(msg.toString());
+            if (data.audio_output?.data) {
+              const buf = Buffer.from(data.audio_output.data, 'base64');
+              if (client.readyState === WebSocket.OPEN) {
+                client.send(buf);
+              }
+            }
+          } catch {}
+        });
+
+        const closeBoth = () => {
+          if (client.readyState === WebSocket.OPEN) client.close();
+          upstream.close();
+        };
+
+        client.on('close', closeBoth);
+        upstream.on('close', closeBoth);
+      })().catch(() => {
+        if (client.readyState === WebSocket.OPEN) client.close();
+      });
+    });
+  });
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,9 +1,11 @@
 import http from 'http';
 import app from './server';
 import { attachSttProxy } from './sttProxy';
+import { attachEviProxy } from './eviProxy';
 
 const server = http.createServer(app);
 attachSttProxy(server);
+attachEviProxy(server);
 
 server.listen(3000, () => {
   console.log('✅ Backend listening on http://localhost:3000');


### PR DESCRIPTION
## Summary
- create `attachEviProxy` WebSocket proxy for Hume Empathic Voice
- expose proxy via HTTP server

## Testing
- `npm run type-check`
- `npm run build` *(fails: Cannot find module 'hume' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_688b7337a5dc83279a3e3fff010c82a3