### PR TITLE
Configure Vercel to use single Node server

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,2 @@
+import app from '../backend/src/server';
+export default app;

--- a/api/solution.ts
+++ b/api/solution.ts
@@ -1,1 +1,0 @@
-export { default } from '../backend/src/routes/solution';

--- a/vercel.json
+++ b/vercel.json
@@ -2,14 +2,14 @@
   "version": 2,
   "builds": [
     {
-      "src": "backend/src/routes/solution.ts",
+      "src": "api/index.ts",
       "use": "@vercel/node"
     }
   ],
   "routes": [
     {
-      "src": "/api/solution",
-      "dest": "backend/src/routes/solution.ts"
+      "src": "/api/(.*)",
+      "dest": "api/index.ts"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- replace API solution function with single server entry
- update `vercel.json` to deploy the Express server

## Testing
- `npm run lint` *(fails: 25 errors, 8 warnings)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688b734295a083278f35e260f24b49aa