### PR TITLE
Update STT websocket URL to use page protocol

### DIFF
--- a/src/utils/voice.ts
+++ b/src/utils/voice.ts
@@ -1,7 +1,11 @@
 export type STTCallback = (text: string) => void;
 
 export function startSttStream(onText: STTCallback) {
-  const ws = new WebSocket("ws://localhost:3000/api/stt");
+  const wsUrl =
+    (window.location.protocol === "https:" ? "wss://" : "ws://") +
+    window.location.host +
+    "/api/stt";
+  const ws = new WebSocket(wsUrl);
 
 
   ws.addEventListener("open", async () => {


### PR DESCRIPTION
## Summary
- connect STT websocket using the page protocol so it works on both HTTP and HTTPS

## Testing
- `npm run lint` *(fails: some unrelated lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688b73475d54832791603414dd34bc04