### PR TITLE
Configure voice timeout

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,1 +1,3 @@
 VITE_ELEVENLABS_VOICE_ID=YOUR_VOICE_ID
+# Timeout for voice collection phase in milliseconds (default 120000)
+VITE_COLLECT_TIMEOUT_MS=120000

--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -6,6 +6,9 @@ import ContactConfirm from "./ContactConfirm";
 import { EviWebAudioPlayer } from "@/utils/eviPlayer";
 import { startSttStream, type STTCallback } from "@/utils/voice";
 
+const COLLECT_TIMEOUT_MS =
+  Number(import.meta.env.VITE_COLLECT_TIMEOUT_MS ?? "120000") || 120000;
+
 interface AgentPanelProps {
   language: "hr" | "en";
 }
@@ -271,7 +274,7 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
       stopStt();
       eviSocketRef.current?.close();
       setPhase("closing");
-    }, 175000);
+    }, COLLECT_TIMEOUT_MS);
   }
 
   async function handleConsent() {


### PR DESCRIPTION
## Summary
- add `VITE_COLLECT_TIMEOUT_MS` example setting
- respect the setting in `AgentPanel` when timing out voice mode

## Testing
- `npm run lint` *(fails: 25 errors, 8 warnings)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688b7347cc5c83278a2b4e6d6495ac81