### PR TITLE
Update WebSocket usage in eviProxy

### DIFF
--- a/backend/src/eviProxy.ts
+++ b/backend/src/eviProxy.ts
@@ -1,7 +1,8 @@
 import { Server as HTTPServer, IncomingMessage } from 'http';
 import { Socket } from 'net';
-import { WebSocketServer, RawData, WebSocket as ClientSocket } from 'ws';
-import WebSocket from 'ws';
+import { WebSocketServer, WebSocket, RawData } from 'ws';
+
+type ClientSocket = WebSocket;
 
 export function attachEviProxy(server: HTTPServer) {
   const wss = new WebSocketServer({ noServer: true });


### PR DESCRIPTION
## Summary
- refactor `eviProxy.ts` to use named `WebSocket` import
- define a `ClientSocket` alias for clarity

## Testing
- `npm --prefix backend run build` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_688b79cfd1ac83278baa6a4ab0f1a755