### PR TITLE
Add ws error event typings and stub express types

### DIFF
--- a/backend/src/express.d.ts
+++ b/backend/src/express.d.ts
@@ -1,0 +1,25 @@
+declare module 'express' {
+  export interface Request {
+    [key: string]: any;
+  }
+  export interface Response {
+    [key: string]: any;
+    status(code: number): this;
+    json(data: any): this;
+    send(data?: any): this;
+    end(): void;
+    setHeader(name: string, value: string): void;
+    write(chunk: any): void;
+  }
+  export interface Router {
+    [key: string]: any;
+    (req?: any, res?: any, next?: any): any;
+    use(...args: any[]): any;
+    get(...args: any[]): any;
+    post(...args: any[]): any;
+  }
+  export function Router(): Router;
+  export type NextFunction = any;
+  const exp: any;
+  export default exp;
+}

--- a/backend/src/hume.d.ts
+++ b/backend/src/hume.d.ts
@@ -1,0 +1,4 @@
+declare module 'hume' {
+  const Hume: any;
+  export = Hume;
+}

--- a/backend/src/openai.d.ts
+++ b/backend/src/openai.d.ts
@@ -1,0 +1,4 @@
+declare module 'openai' {
+  const OpenAI: any;
+  export default OpenAI;
+}

--- a/backend/src/ws.d.ts
+++ b/backend/src/ws.d.ts
@@ -8,12 +8,17 @@ declare module 'ws' {
     send(data: RawData): void;
     close(code?: number, reason?: string): void;
     on(event: 'message', listener: (data: RawData) => void): this;
+    on(event: 'open', listener: () => void): this;
     on(event: 'close', listener: () => void): this;
+    on(event: 'error', listener: (err: Error) => void): this;
   }
 
   export class WebSocketServer {
     constructor(options?: any);
     handleUpgrade(req: any, socket: any, head: any, cb: (client: WebSocket) => void): void;
     on(event: 'connection', listener: (socket: WebSocket, request: any) => void): this;
+    on(event: 'error', listener: (err: Error) => void): this;
   }
+
+  export default WebSocket;
 }


### PR DESCRIPTION
## Summary
- update ws.d.ts to include `error` and `open` handlers and default export
- add stubs for express, openai and hume modules so TypeScript can compile

## Testing
- `npm --prefix backend run build`

------
https://chatgpt.com/codex/tasks/task_e_688b79d3315c832780f5aaf9805f06b9