### PR TITLE
Update defaults to ElevenLabs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ ADMIN_PASS=YOUR_ADMIN_PASS
 ELEVENLABS_VOICE_ID=YOUR_VOICE_ID
 # Set to 1 to disable the speech-to-text websocket proxy
 DISABLE_STT=0
-HUME_API_KEY=OTVtMngHHhC794p7VmVh9yPcRmZHDp4KIqliIeC37uuWmrko
+HUME_API_KEY=YOUR_HUME_API_KEY
 HUME_SECRET_KEY=changeme_if_needed
-TTS_PROVIDER=hume
-STT_PROVIDER=hume
+TTS_PROVIDER=elevenlabs
+STT_PROVIDER=elevenlabs

--- a/backend/dist/routes/tts.js
+++ b/backend/dist/routes/tts.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = require("express");
-// Router for text-to-speech proxy. Switch provider via env TTS_PROVIDER=[hume|elevenlabs] (default hume)
+// Router for text-to-speech proxy. Switch provider via env TTS_PROVIDER=[hume|elevenlabs] (default elevenlabs)
 const router = (0, express_1.Router)();
 router.post('/', async (req, res) => {
     const { text, voiceId = process.env.ELEVENLABS_VOICE_ID, modelId = 'eleven_multilingual_v2' } = req.body;
@@ -10,7 +10,7 @@ router.post('/', async (req, res) => {
         return;
     }
     try {
-        const provider = process.env.TTS_PROVIDER ?? 'hume';
+        const provider = process.env.TTS_PROVIDER ?? 'elevenlabs';
         if (provider === 'hume') {
             const apiRes = await fetch('https://api.hume.ai/v0/tts/stream/file', {
                 method: 'POST',

--- a/backend/dist/sttProxy.js
+++ b/backend/dist/sttProxy.js
@@ -21,7 +21,17 @@ function attachSttProxy(server) {
         if (req.url !== '/api/stt')
             return;
         wss.handleUpgrade(req, socket, head, (client) => {
-            const upstream = new ws_1.WebSocket('wss://api.elevenlabs.io/v1/speech-to-text/ws', undefined, { headers: { 'xi-api-key': process.env.ELEVENLABS_API_KEY ?? '' } });
+            const provider = process.env.STT_PROVIDER ?? 'elevenlabs';
+            const upstream = provider === 'elevenlabs'
+                ? new ws_1.WebSocket('wss://api.elevenlabs.io/v1/speech-to-text/ws', undefined, {
+                    headers: { 'xi-api-key': process.env.ELEVENLABS_API_KEY ?? '' },
+                })
+                : new ws_1.WebSocket('wss://api.hume.ai/v0/stream/models/speech-to-text', [], {
+                    headers: {
+                        'X-Hume-Api-Key': process.env.HUME_API_KEY ?? '',
+                        'X-Hume-Api-Secret': process.env.HUME_SECRET_KEY ?? '',
+                    },
+                });
             client.on('message', (msg) => {
                 if (upstream.readyState === ws_1.WebSocket.OPEN) {
                     upstream.send(msg);

--- a/backend/src/routes/tts.ts
+++ b/backend/src/routes/tts.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response } from "express";
 
-// Router for text-to-speech proxy. Switch provider via env TTS_PROVIDER=[hume|elevenlabs] (default hume)
+// Router for text-to-speech proxy. Switch provider via env TTS_PROVIDER=[hume|elevenlabs] (default elevenlabs)
 const router = Router();
 
 router.post('/', async (req: Request, res: Response) => {
@@ -16,7 +16,7 @@ router.post('/', async (req: Request, res: Response) => {
   }
 
   try {
-    const provider = process.env.TTS_PROVIDER ?? 'hume';
+    const provider = process.env.TTS_PROVIDER ?? 'elevenlabs';
 
     if (provider === 'hume') {
       const apiRes = await fetch('https://api.hume.ai/v0/tts/stream/file', {

--- a/backend/src/sttProxy.ts
+++ b/backend/src/sttProxy.ts
@@ -24,7 +24,7 @@ export function attachSttProxy(server: HTTPServer) {
   server.on('upgrade', (req: IncomingMessage, socket: Socket, head: Buffer) => {
     if (req.url !== '/api/stt') return;
     wss.handleUpgrade(req, socket, head, (client: WebSocket) => {
-      const provider = process.env.STT_PROVIDER ?? 'hume';
+      const provider = process.env.STT_PROVIDER ?? 'elevenlabs';
 
       const upstream =
         provider === 'elevenlabs'


### PR DESCRIPTION
## Summary
- replace example Hume API key with placeholder
- default to ElevenLabs for speech to text and text to speech

## Testing
- `npm run lint` *(fails: 45 errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688ca74277fc83278db8607487ac7f2a