### PR TITLE
Add env var validation

### DIFF
--- a/backend/dist/index.js
+++ b/backend/dist/index.js
@@ -7,6 +7,10 @@ const http_1 = __importDefault(require("http"));
 const server_1 = __importDefault(require("./server"));
 const sttProxy_1 = require("./sttProxy");
 const eviProxy_1 = require("./eviProxy");
+if (!process.env.OPENAI_API_KEY || !process.env.ELEVENLABS_API_KEY) {
+    console.error('❌ Missing OPENAI_API_KEY or ELEVENLABS_API_KEY environment variables.');
+    process.exit(1);
+}
 const server = http_1.default.createServer(server_1.default);
 (0, sttProxy_1.attachSttProxy)(server);
 (0, eviProxy_1.attachEviProxy)(server);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,13 @@ import app from './server';
 import { attachSttProxy } from './sttProxy';
 import { attachEviProxy } from './eviProxy';
 
+if (!process.env.OPENAI_API_KEY || !process.env.ELEVENLABS_API_KEY) {
+  console.error(
+    '❌ Missing OPENAI_API_KEY or ELEVENLABS_API_KEY environment variables.'
+  );
+  process.exit(1);
+}
+
 const server = http.createServer(app);
 attachSttProxy(server);
 attachEviProxy(server);


### PR DESCRIPTION
## Summary
- check that required API keys are present when starting backend

## Testing
- `npm run lint` *(fails: 45 errors, 9 warnings)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688ca74b169c8327a25ae18a9347cb53