### PR TITLE
Handle API errors in finalize

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -5,6 +5,7 @@ import GdprModal from "./GdprModal";
 import ContactConfirm from "./ContactConfirm";
 import { EviWebAudioPlayer } from "@/utils/eviPlayer";
 import { startSttStream } from "@/utils/voice";
+import { toast } from "@/components/ui/sonner";
 
 const COLLECT_TIMEOUT_MS =
   Number(import.meta.env.VITE_COLLECT_TIMEOUT_MS ?? "120000") || 120000;
@@ -62,6 +63,11 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
         },
         body: JSON.stringify({ transcript, language })
       });
+      if (!sumRes.ok) {
+        console.error("Summary API error", sumRes.status, sumRes.statusText);
+        toast.error("Greška pri sažimanju");
+        return;
+      }
       const { summary } = await sumRes.json();
 
       const solRes = await fetch("/api/solution", {
@@ -72,6 +78,11 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
         },
         body: JSON.stringify({ summary, language })
       });
+      if (!solRes.ok) {
+        console.error("Solution API error", solRes.status, solRes.statusText);
+        toast.error("Greška pri rješenju");
+        return;
+      }
       const sol = await solRes.json();
       const solutionText = `${sol.solutionText}\n${sol.cta}`;
 


### PR DESCRIPTION
## Summary
- notify users if summarization or solution API calls fail

## Testing
- `npm run lint` *(fails: unexpected any, no require imports, etc.)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688cad4235ec8327888ef245057cad16