### PR TITLE
Fix missing App render in StrictMode

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import App from './App.tsx'
 import './index.css'               // ← OBAVEZNO da bi sve Tailwind i CSS radilo
 
 createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>             
+  <React.StrictMode>
+    <App />
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- render `App` component inside `React.StrictMode`

## Testing
- `npm run lint` *(fails: Unexpected any in backend files)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688ce239e79083279002eb6beae3c20c