### PR TITLE
Clean up STT proxy WebSocket initialization

### DIFF
--- a/backend/src/sttProxy.ts
+++ b/backend/src/sttProxy.ts
@@ -39,9 +39,6 @@ export function attachSttProxy(server: HTTPServer) {
                 'X-Hume-Api-Secret': process.env.HUME_SECRET_KEY ?? '',
               },
             });
-new WebSocket(
-  `wss://api.hume.ai/v0/stream/models/speech-to-text?apiKey=${process.env.HUME_API_KEY}`,
-    );
       client.on('message', (msg: RawData) => {
         if (upstream.readyState === WebSocket.OPEN) {
           upstream.send(msg);


### PR DESCRIPTION
## Summary
- remove stray WebSocket creation in `backend/src/sttProxy.ts`

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688cf5b2037483278806f79ccaf6c64e