### PR TITLE
Update env local example for voice agent

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,4 @@
 VITE_ELEVENLABS_VOICE_ID=YOUR_VOICE_ID
+VITE_ELEVEN_AGENT_ID=<your_agent_id>
 # Timeout for voice collection phase in milliseconds (default 120000)
 VITE_COLLECT_TIMEOUT_MS=120000

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ environment variables are present:
 
 - `ELEVENLABS_API_KEY` – API key used when connecting to ElevenLabs.
 - `ELEVENLABS_VOICE_ID` – voice identifier for text‑to‑speech.
+- `VITE_ELEVEN_AGENT_ID` – agent identifier for ElevenLabs WebRTC voice.
 - `TTS_PROVIDER` – choose `elevenlabs` (default) or `hume`.
 - `STT_PROVIDER` – choose `elevenlabs` (default) or `hume`.
 - `HUME_API_KEY` and `HUME_SECRET_KEY` – needed when using Hume services.


### PR DESCRIPTION
## Summary
- add `VITE_ELEVEN_AGENT_ID` placeholder to `.env.local.example`
- document ElevenLabs agent ID in README

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any etc.)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688cf5d694308327874bd315089d8e48