### PR TITLE
Add solution modal

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -3,6 +3,7 @@ import { Play, MessageCircle, VolumeX } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import GdprModal from "./GdprModal";
 import ContactConfirm from "./ContactConfirm";
+import SolutionModal from "./SolutionModal";
 import { EviWebAudioPlayer } from "@/utils/eviPlayer";
 import { useConversation } from "@elevenlabs/react";
 import { toast } from "@/components/ui/sonner";
@@ -32,6 +33,9 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
   const [sending, setSending] = useState(false);
   const [contactOpen, setContactOpen] = useState(false);
   const [contactSubmitted, setContactSubmitted] = useState(() => localStorage.getItem("contactDone") === "yes");
+
+  const [solutionOpen, setSolutionOpen] = useState(false);
+  const [solutionTextState, setSolutionTextState] = useState("");
 
   const [phase, setPhase] = useState<"idle" | "intro" | "collect" | "closing" | "ended">("idle");
   const timer = useRef<NodeJS.Timeout>();
@@ -112,6 +116,9 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
       }
       const sol = await solRes.json();
       const solutionText = `${sol.solutionText}\n${sol.cta}`;
+
+      setSolutionTextState(solutionText);
+      setSolutionOpen(true);
 
       await fetch("/api/agent", {
         method: "POST",
@@ -512,6 +519,12 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
         open={contactOpen}
         onSave={handleSaveContact}
         onClose={() => setContactOpen(false)}
+      />
+      <SolutionModal
+        open={solutionOpen}
+        solution={solutionTextState}
+        language={language}
+        onClose={() => setSolutionOpen(false)}
       />
     </div>
   );

--- a/src/components/SolutionModal.tsx
+++ b/src/components/SolutionModal.tsx
@@ -1,0 +1,39 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface SolutionModalProps {
+  open: boolean;
+  solution: string;
+  language: "hr" | "en";
+  onClose: () => void;
+}
+
+export default function SolutionModal({ open, solution, language, onClose }: SolutionModalProps) {
+  const texts = {
+    hr: { title: "AI rješenje", print: "Ispiši", share: "Dijeli" },
+    en: { title: "AI Solution", print: "Print", share: "Share" }
+  } as const;
+
+  const current = texts[language];
+
+  function handleShare() {
+    if (navigator.share) {
+      navigator.share({ title: current.title, text: solution }).catch(() => {});
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{current.title}</DialogTitle>
+        </DialogHeader>
+        <p className="whitespace-pre-line text-sm">{solution}</p>
+        <DialogFooter>
+          <Button type="button" onClick={() => window.print()}>{current.print}</Button>
+          <Button type="button" variant="secondary" onClick={handleShare} disabled={!navigator.share}>{current.share}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- add SolutionModal component
- show solution in modal when conversation ends

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars etc.)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688d3498c9d88327aef7028e783a2510