### PR TITLE
Align progress indicator with conversation phase

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -175,15 +175,23 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
 
   const currentTexts = texts[language];
 
+  // Track progress based on the conversation phase
   useEffect(() => {
-    const interval = setInterval(() => {
-      setCurrentStep(prev => (prev + 1) % 3);
-    }, 5000);
-
-    return () => {
-      clearInterval(interval);
-    };
-  }, []);
+    switch (phase) {
+      case "intro":
+        setCurrentStep(0);
+        break;
+      case "collect":
+        setCurrentStep(1);
+        break;
+      case "closing":
+      case "ended":
+        setCurrentStep(2);
+        break;
+      default:
+        break;
+    }
+  }, [phase]);
 
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove automatic timer that cycled the progress steps
- update the progress step in response to the current `phase`

## Testing
- `npm run lint` *(fails: react-refresh and no-explicit-any errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688d3582c55483278e97844bf76caeb0