### PR TITLE
Update voice session phase handling

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -64,6 +64,9 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
       if (m.source !== "user") {
         setInterim(null);
       }
+      if (phase === "intro" && m.source === "user") {
+        setPhase("collect");
+      }
       setActiveSpeaker(m.source === "user" ? "user" : "agent");
       setMessages((prev) => [
         ...prev,
@@ -287,7 +290,7 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
 
     setActiveSpeaker("user");
 
-    setPhase("collect");
+    setPhase("intro");
     startAt.current = Date.now();
 
     // 2️⃣ zatraži mikrofon
@@ -302,7 +305,9 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
     // 3️⃣ pokreni ElevenLabs WebRTC STT-TTS
     await startSession({
       agentId: import.meta.env.VITE_ELEVEN_AGENT_ID,
-      onConnect: () => {},
+      onConnect: () => {
+        setPhase("collect");
+      },
 
       connectionType: "webrtc",
     });


### PR DESCRIPTION
## Summary
- handle progress bar by setting phase to `intro` before starting ElevenLabs
- move transition to `collect` after WebRTC connects or upon first user message

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688d50f49f08832781b9e641f9747b1a