### PR TITLE
Reset conversation ID after chat ends

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -163,6 +163,7 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ conversationId, role: "system", text: "CONVO_END", phase: "ended" })
       });
+      localStorage.removeItem("convId");
       setPhase("ended");
       setActiveSpeaker(null);
     } catch (err) {


### PR DESCRIPTION
## Summary
- clear the conversation ID when finalizing the call so a new session uses a fresh ID

## Testing
- `npm run lint` *(fails: rule '@typescript-eslint/no-unused-vars' was not found, plus other lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688d54eecb688327936cadb8e04332d6