### PR TITLE
Log user and agent messages

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -76,6 +76,24 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
           time: new Date().toLocaleTimeString(),
         },
       ]);
+      // log turn
+      fetch("/api/agent", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          conversationId,
+          role: m.source === "user" ? "user" : "assistant",
+          text: m.message,
+          phase,
+          mode
+        })
+      }).then(res => {
+        if (!res.ok) {
+          console.error("Agent API error", res.status, res.statusText);
+        }
+      }).catch(err => {
+        console.error("Agent API request failed", err);
+      });
     },
     onDebug: (d: { type: string; response?: string }) => {
   if (d.type === "tentative_agent_response" && d.response) {


### PR DESCRIPTION
## Summary
- call `/api/agent` for every turn in the `onMessage` handler

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars rule not found, plus other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d5b598f4083279c6d4c5268b4483f