### PR TITLE
Handle tentative user transcript

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -61,9 +61,8 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
 
   const { startSession, sendUserMessage, sendUserActivity } = useConversation({
     onMessage: (m) => {
-      if (m.source !== "user") {
-        setInterim(null);
-      }
+      // clear any interim text once a final message is received
+      setInterim(null);
       if (phase === "intro" && m.source === "user") {
         setPhase("collect");
       }
@@ -96,14 +95,21 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
       });
     },
     onDebug: (d: { type: string; response?: string }) => {
-  if (d.type === "tentative_agent_response" && d.response) {
-    setInterim({
-      type: "agent",
-      text: d.response,
-      time: new Date().toLocaleTimeString(),
-    });
-  }
-},
+      if (d.type === "tentative_agent_response" && d.response) {
+        setInterim({
+          type: "agent",
+          text: d.response,
+          time: new Date().toLocaleTimeString(),
+        });
+      }
+      if (d.type === "tentative_user_transcript" && d.response) {
+        setInterim({
+          type: "user",
+          text: d.response,
+          time: new Date().toLocaleTimeString(),
+        });
+      }
+    },
 
   });
 


### PR DESCRIPTION
## Summary
- clear interim messages when final message is received
- show partial user transcripts via `onDebug`

## Testing
- `npm run lint` *(fails: 41 errors, 9 warnings)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688d601e0b508327b445ff3e1fba05ef