### PR TITLE
feat: auto finalize chat mode

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -10,6 +10,7 @@ interface Props {
   setInput: (s: string) => void;
   sending: boolean;
   handleChatSubmit: (e: React.FormEvent) => void;
+  startChatCollect: () => void;
 }
 
 const ControlPanel: React.FC<Props> = ({
@@ -22,6 +23,7 @@ const ControlPanel: React.FC<Props> = ({
   setInput,
   sending,
   handleChatSubmit,
+  startChatCollect,
 }) => (
   <div className="flex flex-col items-center space-y-6">
     <button
@@ -60,7 +62,11 @@ const ControlPanel: React.FC<Props> = ({
         Govor
       </button>
       <button
-        onClick={() => setMode("chat")}
+        data-evt="agent_switch_chat"
+        onClick={() => {
+          setMode("chat");
+          startChatCollect();
+        }}
         className={`px-4 py-2 rounded-full text-sm font-medium transition-all
           ${mode === "chat" ? "bg-white text-gray-800 shadow-md" : "text-gray-600 hover:text-gray-800"}`}
       >


### PR DESCRIPTION
## Summary
- add `startChatCollect` to auto-close chat after timeout
- trigger chat collect when switching to chat and provide manual "Dobij AI rješenje" button

## Testing
- `npx eslint src/components/AgentPanel.tsx src/components/ControlPanel.tsx`
- `npm run type-check`
- `npm run lint` *(fails: Irregular whitespace not allowed, Unexpected any, and A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f3dd9eb64832786dddf2d8f763540