### PR TITLE
fix: close startVoice block

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -456,34 +456,35 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
         mode: "voice",
       }),
     });
-setActiveSpeaker("user");
-setPhase("intro");
-startAt.current = Date.now();
+    setActiveSpeaker("user");
+    setPhase("intro");
+    startAt.current = Date.now();
 
-try {
-  // traži dopuštenje za mikrofon
-  await navigator.mediaDevices.getUserMedia({ audio: true });
+    try {
+      // traži dopuštenje za mikrofon
+      await navigator.mediaDevices.getUserMedia({ audio: true });
 
-  /** ➊ pokreni ElevenLabs sesiju — WebSocket mod */
-  await startSession({
-    agentId: import.meta.env.VITE_ELEVEN_AGENT_ID,
-    connectionType: "websocket",   // ← obavezno navedi “websocket”
-  });
+      /** ➊ pokreni ElevenLabs sesiju — WebSocket mod */
+      await startSession({
+        agentId: import.meta.env.VITE_ELEVEN_AGENT_ID,
+        connectionType: "websocket", // ← obavezno navedi “websocket”
+      });
 
-  setSessionActive(true);
-  setAvatarVisible(true);
+      setSessionActive(true);
+      setAvatarVisible(true);
 
-  /** ➋ nakon COLLECT_TIMEOUT_MS sekundi zatvaramo i tražimo rješenje */
-  timer.current = setTimeout(() => {
-    setPhase("closing");
-    finalize();
-  }, COLLECT_TIMEOUT_MS);
-} catch (err) {
-  addDevLog("startVoice-error", err as Error);
-  alert("Nemoguće pokrenuti glasovni razgovor – vidi konzolu.");
-  setPhase("idle");
-}
+      /** ➋ nakon COLLECT_TIMEOUT_MS sekundi zatvaramo i tražimo rješenje */
+      timer.current = setTimeout(() => {
+        setPhase("closing");
+        finalize();
+      }, COLLECT_TIMEOUT_MS);
+    } catch (err) {
+      addDevLog("startVoice-error", err as Error);
+      alert("Nemoguće pokrenuti glasovni razgovor – vidi konzolu.");
+      setPhase("idle");
+    }
 
+  }
 
   function stopVoice() {
     eviSocketRef.current?.close();
@@ -556,15 +557,19 @@ try {
     setSending(false);
   }
 
-  async function ensureSession() {
-    if (!sessionActive && mode === "voice") {
-    await (startSession as unknown as any)({
-      agentId: import.meta.env.VITE_ELEVEN_AGENT_ID,
-    });
-    setSessionActive(true);
-    setAvatarVisible(true);
+    async function ensureSession() {
+      if (!sessionActive && mode === "voice") {
+        await (
+          startSession as unknown as (
+            opts: { agentId: string }
+          ) => Promise<void>
+        )({
+          agentId: import.meta.env.VITE_ELEVEN_AGENT_ID,
+        });
+        setSessionActive(true);
+        setAvatarVisible(true);
+      }
     }
-  }
 
   return (
     <div className="glass-strong rounded-3xl p-8 shadow-medium h-full">


### PR DESCRIPTION
## Summary
- add missing closing brace to `startVoice` in `AgentPanel`
- replace `any` cast when ensuring session

## Testing
- `npx eslint src/components/AgentPanel.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f7778c53483278a989f5a2f1ec5f8