### PR TITLE
feat: send contact email and enable websocket sessions

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -465,8 +465,9 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
     try {
       await navigator.mediaDevices.getUserMedia({ audio: true });
 
-      await (startSession as unknown as any)({
+      await startSession({
         agentId: import.meta.env.VITE_ELEVEN_AGENT_ID,
+        connectionType: "websocket",
       });
       setSessionActive(true);
       setAvatarVisible(true);
@@ -522,6 +523,15 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
         text: `CONTACT::${email}|${phone}`,
       }),
     });
+    await fetch("/api/sendEmail", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email,
+        phone,
+        painPoints: [], // TODO: puniti kad budeš imao sažetak
+      }),
+    });
     localStorage.setItem("contactDone", "yes");
     setContactSubmitted(true);
     setContactOpen(false);
@@ -556,11 +566,12 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
 
   async function ensureSession() {
     if (!sessionActive && mode === "voice") {
-    await (startSession as unknown as any)({
-      agentId: import.meta.env.VITE_ELEVEN_AGENT_ID,
-    });
-    setSessionActive(true);
-    setAvatarVisible(true);
+      await startSession({
+        agentId: import.meta.env.VITE_ELEVEN_AGENT_ID,
+        connectionType: "websocket",
+      });
+      setSessionActive(true);
+      setAvatarVisible(true);
     }
   }
 


### PR DESCRIPTION
## Summary
- switch ElevenLabs sessions to WebSocket mode
- email contact details via `/api/sendEmail`

## Testing
- `npm run lint` *(fails: Irregular whitespace not allowed, Unexpected any. Specify a different type, A require() style import is forbidden)*
- `npx eslint src/components/AgentPanel.tsx`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688f7d0fa4488327be932d5a02c3205d