### PR TITLE
Add decline option and refactor contact flow

### DIFF
--- a/backend/src/routes/sendEmail.ts
+++ b/backend/src/routes/sendEmail.ts
@@ -11,15 +11,16 @@ interface SendEmailBody {
   email: string;
   phone: string;
   painPoints?: string[];
+  proposal?: string;
 }
 
 /**
  * POST  /api/sendEmail
- * Body: { email, phone, painPoints[] }
+ * Body: { email, phone, painPoints[], proposal }
  */
 router.post("/", async (req: Request, res: Response) => {
   /*  cast → avoids “implicit any” without generics */
-  const { email, phone, painPoints = [] } = req.body as SendEmailBody;
+  const { email, phone, painPoints = [], proposal } = req.body as SendEmailBody;
 
   try {
     /* 1) Nodemailer transporter */
@@ -45,6 +46,7 @@ router.post("/", async (req: Request, res: Response) => {
         <p><b>Email:</b> ${email}</p>
         <p><b>Telefon:</b> ${phone}</p>
         <p><b>Bolne točke:</b> ${painPoints.join(", ")}</p>
+        <p><b>Prijedlog:</b> ${proposal ?? ""}</p>
       `
     });
 

--- a/src/components/ContactConfirm.tsx
+++ b/src/components/ContactConfirm.tsx
@@ -9,9 +9,17 @@ interface Props {
   defaultPhone?: string;
   onSave: (email: string, phone: string) => void;
   onClose: () => void;
+  onDecline?: () => void;
 }
 
-export default function ContactConfirm({ open, defaultEmail = "", defaultPhone = "", onSave, onClose }: Props) {
+export default function ContactConfirm({
+  open,
+  defaultEmail = "",
+  defaultPhone = "",
+  onSave,
+  onClose,
+  onDecline,
+}: Props) {
   const [email, setEmail] = useState(defaultEmail);
   const [phone, setPhone] = useState(defaultPhone);
   const [dirty, setDirty] = useState(false);
@@ -51,8 +59,11 @@ export default function ContactConfirm({ open, defaultEmail = "", defaultPhone =
         </div>
 
         <DialogFooter>
+          <Button variant="outline" onClick={onDecline}>
+            Ne želim ponudu
+          </Button>
           <Button disabled={!ok} onClick={() => onSave(email.trim(), phone.trim())}>
-            Potvrdi
+            Spremi
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary
- add optional decline button to contact confirmation modal
- track contact data in AgentPanel and send proposal email after solution
- support optional proposal field in backend sendEmail route

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 41 errors, 8 warnings)
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688f8703b7d48327aa90f63a9b94735b