### PR TITLE
refactor: remove any from openContactConfirm

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -218,13 +218,13 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
     },
     onError: (e) => console.error("[conversation-error]", e),
     clientTools: {
-      openContactConfirm: () => {
+      openContactConfirm: (_params: unknown) => {
         setContactOpen(true);
         return new Promise<void>((resolve) => {
           openContactResolver.current = () => {
             resolve();
           };
-        }) as unknown as any; // <= satisfy lib typing
+        });
       },
     },
   });


### PR DESCRIPTION
## Summary
- avoid explicit any in openContactConfirm client tool by adding unknown parameter

## Testing
- `npx eslint src/components/AgentPanel.tsx`
- `npm run type-check`
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f98ee92cc83278883eba631e9032c