### PR TITLE
chore: remove custom framer-motion types

### DIFF
--- a/src/types/framer-motion.d.ts
+++ b/src/types/framer-motion.d.ts
@@ -1,4 +1,0 @@
-declare module 'framer-motion' {
-  export const motion: unknown;
-  export const AnimatePresence: unknown;
-}


### PR DESCRIPTION
## Summary
- remove manual framer-motion type declarations to rely on library's bundled types

## Testing
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688fdf941d408327b606d4fbe15cc6aa