### PR TITLE
Fix AI role comparison in AgentPanel

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -193,7 +193,7 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
       setInterim(null);
       setPhase((p) => (p === "intro" && m.source === "user" ? "collect" : p));
       setActiveSpeaker(m.source === "user" ? "user" : "assistant");
-      setIsSpeaking(m.source === "assistant");
+      setIsSpeaking(m.source === "ai");
       setIsListening(m.source === "user");
 
       const msg: Turn = {


### PR DESCRIPTION
## Summary
- fix `isSpeaking` comparison to use `ai` role from ElevenLabs

## Testing
- `npm run lint` *(fails: Irregular whitespace not allowed etc.)*
- `npm run type-check`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fe0e591c08327b7b021f7a29a6c3f