### PR TITLE
Fix state variable declaration typo

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -84,7 +84,7 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
     () => localStorage.getItem("consent") === "yes",
   );
   const [input, setInput] = useState("");
-  the [sending, setSending] = useState(false);
+  const [sending, setSending] = useState(false);
   const [contactOpen, setContactOpen] = useState(false);
   const [contactSubmitted, setContactSubmitted] = useState(
     () => localStorage.getItem("contactDone") === "yes",


### PR DESCRIPTION
## Summary
- fix `sending` state declaration typo in AgentPanel

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fefb8b6f08327bc24f8ee4a574e5b