### PR TITLE
fix: track assistant speech state

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -192,7 +192,7 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
       setInterim(null);
       setPhase((p) => (p === "intro" && m.source === "user" ? "collect" : p));
       setActiveSpeaker(m.source === "user" ? "user" : "assistant");
-      setIsSpeaking(m.source === "ai");
+      setIsSpeaking(m.source === "assistant");
       setIsListening(m.source === "user");
 
       const msg: Turn = {


### PR DESCRIPTION
## Summary
- update AgentPanel to check for `assistant` source when setting speaking state

## Testing
- `npx eslint src/components/AgentPanel.tsx`
- `npm run lint` *(fails: 49 problems)*
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fefbf64bc8327a5ff3af889d834c7