### PR TITLE
Remove unused assistant image import

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -26,7 +26,6 @@ import SolutionModal from "./SolutionModal";
 import { EviWebAudioPlayer } from "@/utils/eviPlayer";
 import { useConversation } from "@elevenlabs/react";
 import { toast } from "@/components/ui/sonner";
-import assistantImg from "@/../assets/agent_1.png";
 
 type Turn = { role: "user" | "assistant"; text: string; time: string };
 


### PR DESCRIPTION
## Summary
- remove unused `assistantImg` import from `AgentPanel`

## Testing
- `npm run lint` *(fails: irregular whitespace, unexpected any, require import style, etc; no unused import warnings for `AgentPanel`)*

------
https://chatgpt.com/codex/tasks/task_e_688fefc3d8e883279891639887582ebc