### PR TITLE
feat: add admin articles management

### DIFF
--- a/backend/src/routes/articles.ts
+++ b/backend/src/routes/articles.ts
@@ -1,0 +1,73 @@
+import { Router, Request, Response, NextFunction } from "express";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+const router = Router();
+const DIR = path.resolve(__dirname, "../../articles");
+const PASS = process.env.ADMIN_PASS as string;
+
+// auth middleware
+router.use((req: Request, res: Response, next: NextFunction) => {
+  if (req.headers["x-admin-pass"] !== PASS) return res.sendStatus(401);
+  next();
+});
+
+interface Article {
+  id: string;
+  title: string;
+  content: string;
+}
+
+// list articles
+router.get("/", async (_req: Request, res: Response) => {
+  const files = (await fs.readdir(DIR)).filter(f => f.endsWith(".json"));
+  const data: Article[] = await Promise.all(
+    files.map(async file => JSON.parse(await fs.readFile(path.join(DIR, file), "utf8")))
+  );
+  res.json(data);
+});
+
+// get single article
+router.get("/:id", async (req: Request, res: Response) => {
+  const p = path.join(DIR, `${req.params.id}.json`);
+  try {
+    const json = JSON.parse(await fs.readFile(p, "utf8"));
+    res.json(json);
+  } catch {
+    res.sendStatus(404);
+  }
+});
+
+// create article
+router.post("/", async (req: Request, res: Response) => {
+  const id = randomUUID();
+  const article: Article = { id, title: req.body.title ?? "", content: req.body.content ?? "" };
+  await fs.writeFile(path.join(DIR, `${id}.json`), JSON.stringify(article, null, 2));
+  res.status(201).json(article);
+});
+
+// update article
+router.put("/:id", async (req: Request, res: Response) => {
+  const p = path.join(DIR, `${req.params.id}.json`);
+  try {
+    const article: Article = { id: req.params.id, title: req.body.title ?? "", content: req.body.content ?? "" };
+    await fs.writeFile(p, JSON.stringify(article, null, 2));
+    res.json(article);
+  } catch {
+    res.sendStatus(404);
+  }
+});
+
+// delete article
+router.delete("/:id", async (req: Request, res: Response) => {
+  const p = path.join(DIR, `${req.params.id}.json`);
+  try {
+    await fs.unlink(p);
+    res.sendStatus(204);
+  } catch {
+    res.sendStatus(404);
+  }
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -9,6 +9,7 @@ import ttsRouter from "./routes/tts";
 import transcriptsRouter from "./routes/transcripts";
 import solutionRouter from "./routes/solution";
 import summaryRouter from "./routes/summary";
+import articlesRouter from "./routes/articles";
 
 const app = express();
 
@@ -35,6 +36,7 @@ app.use("/api/transcripts", transcriptsRouter);
 app.use("/api/solution", solutionRouter);
 app.use("/api/summary", summaryRouter);
 app.use("/api/sendEmail", sendEmailRouter);
+app.use("/api/articles", articlesRouter);
 
 /* 404 + error */
 app.use((_req: Request, res: Response) => res.status(404).json({ error: "not_found" }));

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -9,6 +9,7 @@ import {
   TableRow as Tr,
   TableCell as Td,
 } from "@/components/ui/table";
+import Articles from "./admin/Articles";
 
 interface Row {
   id: string;
@@ -21,15 +22,16 @@ interface Row {
 export default function Admin() {
   const [pass, setPass] = useState(() => sessionStorage.getItem("adminPass") || "");
   const [rows, setRows] = useState<Row[]>([]);
-  const [selected, setSelected] = useState<any | null>(null);
+  const [selected, setSelected] = useState<Record<string, unknown> | null>(null);
+  const [tab, setTab] = useState<"transcripts" | "articles">("transcripts");
 
   useEffect(() => {
-    if (!pass) return;
+    if (!pass || tab !== "transcripts") return;
     fetch("/api/transcripts", { headers: { "x-admin-pass": pass } })
       .then(r => r.json())
       .then(setRows)
       .catch(() => { setPass(""); sessionStorage.removeItem("adminPass"); });
-  }, [pass]);
+  }, [pass, tab]);
 
   function handleDelete(id: string) {
     if (!confirm("Delete transcript?")) return;
@@ -39,37 +41,87 @@ export default function Admin() {
 
   return (
     <div className="p-6 max-w-5xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Transkripti</h1>
+      <div className="flex gap-2 mb-4">
+        <Button
+          variant={tab === "transcripts" ? "default" : "ghost"}
+          onClick={() => setTab("transcripts")}
+        >
+          Transkripti
+        </Button>
+        <Button
+          variant={tab === "articles" ? "default" : "ghost"}
+          onClick={() => setTab("articles")}
+        >
+          Članci
+        </Button>
+      </div>
 
-      <Table>
-        <Thead>
-          <Tr><Th>ID</Th><Th>Start</Th><Th>Turns</Th><Th>Kontakt</Th><Th></Th></Tr>
-        </Thead>
-        <Tbody>
-          {rows.map(r=>(
-            <Tr key={r.id} className="hover:bg-muted" onClick={()=>fetch(`/api/transcripts/${r.id}`,{headers:{ "x-admin-pass":pass }})
-                                     .then(r=>r.json()).then(setSelected)}>
-              <Td className="font-mono text-xs">{r.id.slice(0,8)}</Td>
-              <Td>{new Date(r.created).toLocaleString()}</Td>
-              <Td>{r.turns}</Td>
-              <Td>{r.hasContact ? "✔️" : ""}</Td>
-              <Td><Button size="sm" variant="ghost" onClick={(e)=>{e.stopPropagation();handleDelete(r.id);}}>🗑️</Button></Td>
-            </Tr>
-          ))}
-        </Tbody>
-      </Table>
+      {tab === "transcripts" ? (
+        <div>
+          <h1 className="text-2xl font-bold mb-4">Transkripti</h1>
 
-      {selected && (
-        <div className="mt-6">
-          <h2 className="font-semibold mb-2">Detalji</h2>
-          <textarea className="w-full h-80 text-xs bg-muted p-2 rounded"
-            readOnly value={JSON.stringify(selected,null,2)} />
+          <Table>
+            <Thead>
+              <Tr>
+                <Th>ID</Th>
+                <Th>Start</Th>
+                <Th>Turns</Th>
+                <Th>Kontakt</Th>
+                <Th></Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {rows.map(r => (
+                <Tr
+                  key={r.id}
+                  className="hover:bg-muted"
+                  onClick={() =>
+                    fetch(`/api/transcripts/${r.id}`, {
+                      headers: { "x-admin-pass": pass },
+                    })
+                      .then(r => r.json())
+                      .then(setSelected)
+                  }
+                >
+                  <Td className="font-mono text-xs">{r.id.slice(0, 8)}</Td>
+                  <Td>{new Date(r.created).toLocaleString()}</Td>
+                  <Td>{r.turns}</Td>
+                  <Td>{r.hasContact ? "✔️" : ""}</Td>
+                  <Td>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={e => {
+                        e.stopPropagation();
+                        handleDelete(r.id);
+                      }}
+                    >
+                      🗑️
+                    </Button>
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+
+          {selected && (
+            <div className="mt-6">
+              <h2 className="font-semibold mb-2">Detalji</h2>
+              <textarea
+                className="w-full h-80 text-xs bg-muted p-2 rounded"
+                readOnly
+                value={JSON.stringify(selected, null, 2)}
+              />
+            </div>
+          )}
         </div>
+      ) : (
+        <Articles pass={pass} />
       )}
 
       <PasswordModal
         open={!pass}
-        onSubmit={(p)=>{
+        onSubmit={p => {
           sessionStorage.setItem("adminPass", p);
           setPass(p);
         }}

--- a/src/pages/admin/Articles.tsx
+++ b/src/pages/admin/Articles.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Table,
+  TableBody as Tbody,
+  TableHead as Th,
+  TableHeader as Thead,
+  TableRow as Tr,
+  TableCell as Td,
+} from "@/components/ui/table";
+
+interface Article {
+  id: string;
+  title: string;
+  content: string;
+}
+
+interface Props {
+  pass: string;
+}
+
+export default function Articles({ pass }: Props) {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [form, setForm] = useState<{ id?: string; title: string; content: string }>({
+    title: "",
+    content: "",
+  });
+
+  useEffect(() => {
+    if (!pass) return;
+    fetch("/api/articles", { headers: { "x-admin-pass": pass } })
+      .then(r => r.json())
+      .then(setArticles)
+      .catch(() => setArticles([]));
+  }, [pass]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const method = form.id ? "PUT" : "POST";
+    const url = form.id ? `/api/articles/${form.id}` : "/api/articles";
+    fetch(url, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        "x-admin-pass": pass,
+      },
+      body: JSON.stringify({ title: form.title, content: form.content }),
+    })
+      .then(r => r.json())
+      .then((a: Article) => {
+        setArticles(prev =>
+          prev.some(x => x.id === a.id)
+            ? prev.map(x => (x.id === a.id ? a : x))
+            : [...prev, a]
+        );
+        setForm({ title: "", content: "" });
+      });
+  }
+
+  function handleEdit(a: Article) {
+    setForm(a);
+  }
+
+  function handleDelete(id: string) {
+    if (!confirm("Delete article?")) return;
+    fetch(`/api/articles/${id}`, {
+      method: "DELETE",
+      headers: { "x-admin-pass": pass },
+    }).then(() => setArticles(arts => arts.filter(a => a.id !== id)));
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Članci</h1>
+      <Table>
+        <Thead>
+          <Tr>
+            <Th>ID</Th>
+            <Th>Naslov</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {articles.map(a => (
+            <Tr key={a.id}>
+              <Td className="font-mono text-xs">{a.id.slice(0, 8)}</Td>
+              <Td>{a.title}</Td>
+              <Td className="text-right space-x-2">
+                <Button size="sm" variant="ghost" onClick={() => handleEdit(a)}>
+                  ✏️
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => handleDelete(a.id)}
+                >
+                  🗑️
+                </Button>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+
+      <form onSubmit={handleSubmit} className="mt-6 space-y-2">
+        <Input
+          placeholder="Naslov"
+          value={form.title}
+          onChange={e => setForm({ ...form, title: e.target.value })}
+        />
+        <Textarea
+          placeholder="Sadržaj"
+          value={form.content}
+          onChange={e => setForm({ ...form, content: e.target.value })}
+          className="h-40"
+        />
+        <Button type="submit">{form.id ? "Spremi" : "Dodaj"}</Button>
+        {form.id && (
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => setForm({ title: "", content: "" })}
+          >
+            Odustani
+          </Button>
+        )}
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add server route for CRUD of articles
- add admin page with tabs for transcripts and articles
- allow creating, editing, and deleting articles in UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6890abde02308327a2ecf34875ef4fdf