### PR TITLE
fix: resolve DOMPurify import

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -23,8 +23,7 @@
 
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "dompurify": ["./src/lib/dompurify"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "dompurify": ["./src/lib/dompurify"]
+      "@/*": ["./src/*"]
     },
     "noImplicitAny": false,
     "noUnusedParameters": false,


### PR DESCRIPTION
## Summary
- fix DOMPurify import resolution by removing path alias

## Testing
- `npm run lint` (fails: An interface declaring no members is equivalent to its supertype and other errors)
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689110d10e6c832783c16099e76c943f