### PR TITLE
Improve UI consistency and fix blog rendering

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -334,7 +334,12 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
         <>
           Razgovor se snima i transkribira radi poboljšanja usluge; podaci se
           čuvaju šifrirano i usklađeni su s GDPR-om.{' '}
-          <a className="underline" href="/privacy">
+          <a
+            className="underline text-white cursor-pointer"
+            href="/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Detalji o obradi podataka
           </a>
           .
@@ -353,7 +358,12 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
         <>
           Conversation is recorded and transcribed to improve the service; data
           is stored encrypted and compliant with GDPR.{' '}
-          <a className="underline" href="/privacy">
+          <a
+            className="underline text-white cursor-pointer"
+            href="/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Details about data processing
           </a>
           .
@@ -617,9 +627,9 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
                   className="absolute inset-0 rounded-2xl overflow-hidden"
                 >
                   <img
-                    src="/path/to/placeholder-image.jpg" // Zamijenite s pravim putem do slike
-                    alt="Placeholder"
-                    className="w-full h-full object-cover"
+                    src="/assets/BrainAI.png"
+                    alt="BrainAI"
+                    className="w-full h-full object-contain"
                   />
                 </motion.div>
               ) : (

--- a/src/components/ContactConfirm.tsx
+++ b/src/components/ContactConfirm.tsx
@@ -1,7 +1,5 @@
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { X } from "lucide-react";
 
 interface Props {
   open: boolean;
@@ -24,49 +22,110 @@ export default function ContactConfirm({
   const [phone, setPhone] = useState(defaultPhone);
   const [dirty, setDirty] = useState(false);
 
+  useEffect(() => {
+    if (open) {
+      setEmail(defaultEmail);
+      setPhone(defaultPhone);
+      setDirty(false);
+    }
+  }, [open, defaultEmail, defaultPhone]);
+
   function validEmail(e: string) {
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e);
   }
+
   function validPhone(p: string) {
     return /^[0-9+()\- ]{6,}$/.test(p);
   }
 
   const ok = validEmail(email) && validPhone(phone);
 
-  return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Potvrdite svoje kontakt podatke</DialogTitle>
-        </DialogHeader>
+  if (!open) return null;
 
-        <div className="space-y-4 py-2">
-          <Input
-            placeholder="E-mail"
-            value={email}
-            onChange={e => { setEmail(e.target.value); setDirty(true); }}
-          />
-          <Input
-            placeholder="Telefon"
-            value={phone}
-            onChange={e => { setPhone(e.target.value); setDirty(true); }}
-          />
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
+      <div className="glass-strong rounded-3xl p-8 w-full max-w-md shadow-strong">
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h2 className="text-2xl font-bold text-white mb-1">
+              Uredi svoje kontakt podatke
+            </h2>
+            <p className="text-white text-sm">Odgovoramo u roku od 24 sata</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-white/20 rounded-full transition-smooth"
+            aria-label="Zatvori"
+          >
+            <X className="w-6 h-6" />
+          </button>
+        </div>
+
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            if (!ok) return;
+            onSave(email.trim(), phone.trim());
+          }}
+          className="space-y-4"
+        >
+          <div>
+            <label className="block text-sm font-medium text-white mb-2">
+              E-mail
+            </label>
+            <input
+              type="email"
+              placeholder="E-mail"
+              value={email}
+              onChange={e => {
+                setEmail(e.target.value);
+                setDirty(true);
+              }}
+              className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-white mb-2">
+              Telefon
+            </label>
+            <input
+              type="tel"
+              placeholder="Telefon"
+              value={phone}
+              onChange={e => {
+                setPhone(e.target.value);
+                setDirty(true);
+              }}
+              className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
+            />
+          </div>
+
           {dirty && !ok && (
-            <p className="text-xs text-red-600">
+            <p className="text-xs text-red-400">
               Unesite valjanu e-mail adresu i broj telefona.
             </p>
           )}
-        </div>
 
-        <DialogFooter>
-          <Button variant="outline" onClick={onDecline}>
-            Ne želim ponudu
-          </Button>
-          <Button disabled={!ok} onClick={() => onSave(email.trim(), phone.trim())}>
-            Spremi
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+          <div className="flex space-x-3 pt-4">
+            <button
+              type="button"
+              onClick={onDecline}
+              className="w-full bg-white/20 hover:bg-white/30 text-white py-3 rounded-xl font-semibold transition-smooth"
+            >
+              Ne želim ponudu
+            </button>
+            <button
+              type="submit"
+              disabled={!ok}
+              className="w-full bg-gradient-primary text-white py-3 rounded-xl font-semibold shadow-medium hover:shadow-strong transition-smooth hover:scale-[1.02] disabled:opacity-50"
+            >
+              Spremi
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
   );
 }
+

--- a/src/components/QuestionModal.tsx
+++ b/src/components/QuestionModal.tsx
@@ -157,7 +157,7 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
                 <h2 className="text-2xl font-bold text-foreground mb-1">
                   {currentTexts.title}
                 </h2>
-                <p className="text-muted-foreground">{currentTexts.subtitle}</p>
+                <p className="text-white">{currentTexts.subtitle}</p>
               </div>
               <button
                 onClick={onClose}

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -50,7 +50,7 @@ const BlogPost = () => {
         el.replaceWith(span);
       });
 
-    const html = doc.body.innerHTML;
+    const html = doc.body.innerHTML.replace(/&nbsp;|&amp;nbsp;/g, ' ');
 
     return DOMPurify.sanitize(html, {
       ADD_TAGS: ['iframe', 'div', 'span'],


### PR DESCRIPTION
## Summary
- Show BrainAI image in transcript placeholder
- Strip `&nbsp;` artifacts from blog content
- Make privacy details link clickable
- Restyle contact edit form to match question modal and brighten subtitle

## Testing
- `npm run lint` (fails: An interface declaring no members is equivalent to its supertype, no-irregular-whitespace, A `require()` style import is forbidden)
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68914f0e1c808327a3ad8e82f01b8a5f