### PR TITLE
Polish landing layout and navigation

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -45,7 +45,7 @@ interface AgentPanelProps {
 }
 
 const AgentPanel = ({ language }: AgentPanelProps) => {
-  const [currentStep, setCurrentStep] = useState(0);
+  const [currentStep, setCurrentStep] = useState(-1);
   const [messages, setMessages] = useState<Turn[]>([]);
   const [interim, setInterim] = useState<Turn | null>(null);
   const [mode, setMode] = useState<"voice" | "chat">("voice");

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,13 +25,16 @@ const Header = ({ language, onLanguageChange }: HeaderProps) => {
     <header className="sticky top-0 z-50 w-full border-b border-white/20 backdrop-blur-lg bg-gray-900/50">
       <div className="container mx-auto px-6 h-16 flex items-center justify-between">
         {/* Logo */}
-        <div className="flex items-center">
+        <a href="/" className="flex items-center space-x-2 group">
           <img
             src="/assets/NeuroBiz_Logo_1%20copy.png"
             alt="Neurobiz logo"
-            className="h-10 w-auto transition-transform hover:scale-105"
+            className="h-10 w-auto transition-transform group-hover:scale-105"
           />
-        </div>
+          <span className="text-xl font-bold text-white group-hover:text-blue-300">
+            {texts[language].logo}
+          </span>
+        </a>
 
         {/* Right side - Contact, Question, Language switch and email */}
         <div className="flex items-center space-x-6">

--- a/src/components/QuestionModal.tsx
+++ b/src/components/QuestionModal.tsx
@@ -151,7 +151,7 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
-      <div className="glass-strong rounded-3xl p-8 w-full max-w-2xl max-h-[90vh] overflow-y-auto shadow-strong">
+      <div className="glass-strong rounded-3xl p-8 w-full max-w-2xl shadow-strong">
         {!isSubmitted ? (
           <>
             {/* Header */}
@@ -172,11 +172,11 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
             </div>
 
             {/* Form */}
-            <form onSubmit={handleSubmit} className="space-y-6">
+            <form onSubmit={handleSubmit} className="space-y-4">
               {/* Name fields */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">
+                  <label className="block text-base font-bold text-foreground mb-2">
                     {currentTexts.firstName} *
                   </label>
                   <input
@@ -188,7 +188,7 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">
+                  <label className="block text-base font-bold text-foreground mb-2">
                     {currentTexts.lastName} *
                   </label>
                   <input
@@ -203,7 +203,7 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
 
               {/* Email */}
               <div>
-                <label className="block text-sm font-medium text-foreground mb-2">
+                <label className="block text-base font-bold text-foreground mb-2">
                   {currentTexts.email} *
                 </label>
                 <input
@@ -217,7 +217,7 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
 
               {/* Company */}
               <div>
-                <label className="block text-sm font-medium text-foreground mb-2">
+                <label className="block text-base font-bold text-foreground mb-2">
                   {currentTexts.company}
                 </label>
                 <input
@@ -231,7 +231,7 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
               {/* Industry and Team Size */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">
+                  <label className="block text-base font-bold text-foreground mb-2">
                     {currentTexts.industry}
                   </label>
                   <select
@@ -247,7 +247,7 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
                   </select>
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">
+                  <label className="block text-base font-bold text-foreground mb-2">
                     {currentTexts.teamSize}
                   </label>
                   <select
@@ -266,7 +266,7 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
 
               {/* Repetitive Task */}
               <div>
-                <label className="block text-sm font-medium text-foreground mb-2">
+                <label className="block text-base font-bold text-foreground mb-2">
                   {currentTexts.repetitiveTask}
                 </label>
                 <input
@@ -280,7 +280,7 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
 
               {/* AI Usage */}
               <div>
-                <label className="block text-sm font-medium text-foreground mb-2">
+                <label className="block text-base font-bold text-foreground mb-2">
                   {currentTexts.aiUsage}
                 </label>
                 <div className="space-y-2">
@@ -294,20 +294,20 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
                         onChange={(e) => handleInputChange('aiUsage', e.target.value)}
                         className="w-4 h-4 text-primary focus:ring-2 focus:ring-primary"
                       />
-                      <span className="text-sm text-foreground">{level}</span>
-                    </label>
+                      <span className="text-base font-bold text-foreground">{level}</span>
+                      </label>
                   ))}
                 </div>
               </div>
 
               {/* Question */}
               <div>
-                <label className="block text-sm font-medium text-foreground mb-2">
+                <label className="block text-base font-bold text-foreground mb-2">
                   {currentTexts.question} *
                 </label>
                 <textarea
                   required
-                  rows={4}
+                  rows={3}
                   value={formData.question}
                   onChange={(e) => handleInputChange('question', e.target.value)}
                   className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth resize-none"
@@ -324,7 +324,7 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
                     onChange={(e) => handleInputChange('wantResponse', e.target.checked)}
                     className="w-4 h-4 text-primary focus:ring-2 focus:ring-primary rounded"
                   />
-                  <span className="text-sm text-foreground">{currentTexts.wantResponse}</span>
+                  <span className="text-base font-bold text-foreground">{currentTexts.wantResponse}</span>
                 </label>
                 <label className="flex items-center space-x-3 cursor-pointer">
                   <input
@@ -333,7 +333,7 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
                     onChange={(e) => handleInputChange('newsletter', e.target.checked)}
                     className="w-4 h-4 text-primary focus:ring-2 focus:ring-primary rounded"
                   />
-                  <span className="text-sm text-foreground">{currentTexts.newsletter}</span>
+                  <span className="text-base font-bold text-foreground">{currentTexts.newsletter}</span>
                 </label>
               </div>
 

--- a/src/components/VoiceAgentDisplay.tsx
+++ b/src/components/VoiceAgentDisplay.tsx
@@ -56,7 +56,7 @@ export default function VoiceAgentDisplay({
               {title}
             </motion.h1>
             <motion.p
-              className="text-slate-300 text-lg mb-12 max-w-md"
+              className="text-slate-300 text-lg mb-12 max-w-md mx-auto"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.4, duration: 0.6 }}
@@ -65,7 +65,7 @@ export default function VoiceAgentDisplay({
             </motion.p>
             <motion.button
               onClick={onStartChat}
-              className="group relative bg-gradient-to-r from-blue-600 to-purple-600 text-white text-xl px-12 py-6 rounded-2xl flex items-center gap-4 shadow-2xl hover:shadow-blue-500/25 transition-all duration-300"
+              className="group relative mx-auto bg-gradient-to-r from-white to-gray-200 text-purple-800 text-2xl font-bold px-14 py-7 rounded-2xl flex items-center gap-4 shadow-2xl hover:shadow-purple-500/25 transition-all duration-300"
               initial={{ scale: 0, rotate: -180 }}
               animate={{ scale: 1, rotate: 0 }}
               transition={{ delay: 0.6, duration: 0.8, type: "spring" }}
@@ -79,7 +79,7 @@ export default function VoiceAgentDisplay({
                 <Play className="w-7 h-7" />
               </motion.div>
               {startLabel}
-              <div className="absolute inset-0 rounded-2xl bg-gradient-to-r from-blue-400 to-purple-400 opacity-0 group-hover:opacity-20 transition-opacity duration-300" />
+              <div className="absolute inset-0 rounded-2xl bg-gradient-to-r from-purple-200 to-purple-300 opacity-0 group-hover:opacity-20 transition-opacity duration-300" />
             </motion.button>
           </motion.div>
         ) : (

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -103,14 +103,12 @@ const BlogPost = () => {
       backToHome: 'Nazad na početnu',
       relatedArticles: 'Povezani članci',
       shareArticle: 'Podijeli članak',
-      readingTime: 'min čitanja',
       author: 'Autor'
     },
     en: {
       backToHome: 'Back to home',
       relatedArticles: 'Related Articles',
       shareArticle: 'Share article',
-      readingTime: 'min read',
       author: 'Author'
     }
   };
@@ -125,19 +123,18 @@ const BlogPost = () => {
         <div className="max-w-4xl mx-auto">
           <button
             onClick={() => navigate('/')}
-            className="inline-flex items-center space-x-2 text-muted-foreground hover:text-primary transition-colors mb-8"
+            className="inline-flex items-center space-x-2 text-lg font-bold text-primary hover:underline mb-8"
           >
-            <ArrowLeft className="w-4 h-4" />
+            <ArrowLeft className="w-5 h-5" />
             <span>{currentTexts.backToHome}</span>
           </button>
 
           <div className="mb-8">
-            <div className="flex items-center space-x-4 text-sm text-muted-foreground mb-4">
+            <div className="flex items-center text-sm text-muted-foreground mb-4">
               <div className="flex items-center space-x-1">
                 <User className="w-4 h-4" />
                 <span>{currentPost.author ?? ''}</span>
               </div>
-              <span>5 {currentTexts.readingTime}</span>
             </div>
 
             <h1 className="text-4xl font-bold text-foreground leading-tight mb-4">


### PR DESCRIPTION
## Summary
- Center subtitle and give start button a light, larger style for better contrast
- Link header logo and text back to homepage and delay progress tracker until conversation begins
- Simplify question modal and article page: bold labels, remove scroll and reading time, highlight back links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 47 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689237e870d88327bbefbac2836bae57