### PR TITLE
feat: split question form into two-step modal

### DIFF
--- a/src/components/QuestionModal.tsx
+++ b/src/components/QuestionModal.tsx
@@ -22,6 +22,7 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
     newsletter: false
   });
   const [isSubmitted, setIsSubmitted] = useState(false);
+  const [step, setStep] = useState(1);
 
   const texts = {
     hr: {
@@ -39,6 +40,9 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
       wantResponse: 'Želim povratni e-mail s odgovorom',
       newsletter: 'Želim primati newsletter',
       submit: 'Pošaljite pitanje',
+      next: 'Dalje',
+      back: 'Nazad',
+      step: 'Korak',
       submitting: 'Šalje se...',
       successTitle: 'Hvala na pitanju!',
       successMessage: 'Odgovor ćete dobiti u roku od 24 sata na navedenu e-mail adresu.',
@@ -84,6 +88,9 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
       wantResponse: 'I want an email response',
       newsletter: 'I want to receive newsletter',
       submit: 'Send Question',
+      next: 'Next',
+      back: 'Back',
+      step: 'Step',
       submitting: 'Sending...',
       successTitle: 'Thank you for your question!',
       successMessage: 'You will receive a response within 24 hours at the provided email address.',
@@ -147,6 +154,13 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
     setFormData(prev => ({ ...prev, [field]: value }));
   };
 
+  const handleNext = () => {
+    if (!formData.firstName || !formData.lastName || !formData.email) return;
+    setStep(2);
+  };
+
+  const handleBack = () => setStep(1);
+
   if (!isOpen) return null;
 
   return (
@@ -171,181 +185,218 @@ const QuestionModal = ({ isOpen, onClose, language }: QuestionModalProps) => {
               </button>
             </div>
 
+            {/* Progress */}
+            <div className="mb-6">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-sm text-white font-bold">
+                  {currentTexts.step} {step}/2
+                </span>
+              </div>
+              <div className="w-full bg-white/20 rounded-full h-2">
+                <div
+                  className="bg-gradient-primary h-2 rounded-full"
+                  style={{ width: step === 1 ? '50%' : '100%' }}
+                />
+              </div>
+            </div>
+
             {/* Form */}
             <form onSubmit={handleSubmit} className="space-y-4">
-              {/* Name fields */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-base font-bold text-foreground mb-2">
-                    {currentTexts.firstName} *
-                  </label>
-                  <input
-                    type="text"
-                    required
-                    value={formData.firstName}
-                    onChange={(e) => handleInputChange('firstName', e.target.value)}
-                    className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
-                  />
-                </div>
-                <div>
-                  <label className="block text-base font-bold text-foreground mb-2">
-                    {currentTexts.lastName} *
-                  </label>
-                  <input
-                    type="text"
-                    required
-                    value={formData.lastName}
-                    onChange={(e) => handleInputChange('lastName', e.target.value)}
-                    className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
-                  />
-                </div>
-              </div>
-
-              {/* Email */}
-              <div>
-                <label className="block text-base font-bold text-foreground mb-2">
-                  {currentTexts.email} *
-                </label>
-                <input
-                  type="email"
-                  required
-                  value={formData.email}
-                  onChange={(e) => handleInputChange('email', e.target.value)}
-                  className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
-                />
-              </div>
-
-              {/* Company */}
-              <div>
-                <label className="block text-base font-bold text-foreground mb-2">
-                  {currentTexts.company}
-                </label>
-                <input
-                  type="text"
-                  value={formData.company}
-                  onChange={(e) => handleInputChange('company', e.target.value)}
-                  className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
-                />
-              </div>
-
-              {/* Industry and Team Size */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-base font-bold text-foreground mb-2">
-                    {currentTexts.industry}
-                  </label>
-                  <select
-                    value={formData.industry}
-                    onChange={(e) => handleInputChange('industry', e.target.value)}
-                    className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
-                  >
-                    {currentTexts.industries.map((industry, index) => (
-                      <option key={index} value={index === 0 ? '' : industry}>
-                        {industry}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-base font-bold text-foreground mb-2">
-                    {currentTexts.teamSize}
-                  </label>
-                  <select
-                    value={formData.teamSize}
-                    onChange={(e) => handleInputChange('teamSize', e.target.value)}
-                    className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
-                  >
-                    {currentTexts.teamSizes.map((size, index) => (
-                      <option key={index} value={index === 0 ? '' : size}>
-                        {size}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-
-              {/* Repetitive Task */}
-              <div>
-                <label className="block text-base font-bold text-foreground mb-2">
-                  {currentTexts.repetitiveTask}
-                </label>
-                <input
-                  type="text"
-                  value={formData.repetitiveTask}
-                  onChange={(e) => handleInputChange('repetitiveTask', e.target.value)}
-                  className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
-                  placeholder="npr. kreiranje ponuda, unos računa..."
-                />
-              </div>
-
-              {/* AI Usage */}
-              <div>
-                <label className="block text-base font-bold text-foreground mb-2">
-                  {currentTexts.aiUsage}
-                </label>
-                <div className="space-y-2">
-                  {currentTexts.aiUsageLevels.map((level, index) => (
-                    <label key={index} className="flex items-center space-x-3 cursor-pointer">
-                      <input
-                        type="radio"
-                        name="aiUsage"
-                        value={level}
-                        checked={formData.aiUsage === level}
-                        onChange={(e) => handleInputChange('aiUsage', e.target.value)}
-                        className="w-4 h-4 text-primary focus:ring-2 focus:ring-primary"
-                      />
-                      <span className="text-base font-bold text-foreground">{level}</span>
+              {step === 1 ? (
+                <>
+                  {/* Name fields */}
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-base font-bold text-foreground mb-2">
+                        {currentTexts.firstName} *
                       </label>
-                  ))}
-                </div>
-              </div>
+                      <input
+                        type="text"
+                        required
+                        value={formData.firstName}
+                        onChange={(e) => handleInputChange('firstName', e.target.value)}
+                        className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-base font-bold text-foreground mb-2">
+                        {currentTexts.lastName} *
+                      </label>
+                      <input
+                        type="text"
+                        required
+                        value={formData.lastName}
+                        onChange={(e) => handleInputChange('lastName', e.target.value)}
+                        className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
+                      />
+                    </div>
+                  </div>
 
-              {/* Question */}
-              <div>
-                <label className="block text-base font-bold text-foreground mb-2">
-                  {currentTexts.question} *
-                </label>
-                <textarea
-                  required
-                  rows={3}
-                  value={formData.question}
-                  onChange={(e) => handleInputChange('question', e.target.value)}
-                  className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth resize-none"
-                  placeholder="Opišite svoj izazov ili pitanje..."
-                />
-              </div>
+                  {/* Email */}
+                  <div>
+                    <label className="block text-base font-bold text-foreground mb-2">
+                      {currentTexts.email} *
+                    </label>
+                    <input
+                      type="email"
+                      required
+                      value={formData.email}
+                      onChange={(e) => handleInputChange('email', e.target.value)}
+                      className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
+                    />
+                  </div>
 
-              {/* Checkboxes */}
-              <div className="space-y-3">
-                <label className="flex items-center space-x-3 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={formData.wantResponse}
-                    onChange={(e) => handleInputChange('wantResponse', e.target.checked)}
-                    className="w-4 h-4 text-primary focus:ring-2 focus:ring-primary rounded"
-                  />
-                  <span className="text-base font-bold text-foreground">{currentTexts.wantResponse}</span>
-                </label>
-                <label className="flex items-center space-x-3 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={formData.newsletter}
-                    onChange={(e) => handleInputChange('newsletter', e.target.checked)}
-                    className="w-4 h-4 text-primary focus:ring-2 focus:ring-primary rounded"
-                  />
-                  <span className="text-base font-bold text-foreground">{currentTexts.newsletter}</span>
-                </label>
-              </div>
+                  {/* Company */}
+                  <div>
+                    <label className="block text-base font-bold text-foreground mb-2">
+                      {currentTexts.company}
+                    </label>
+                    <input
+                      type="text"
+                      value={formData.company}
+                      onChange={(e) => handleInputChange('company', e.target.value)}
+                      className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
+                    />
+                  </div>
 
-              {/* Submit Button */}
-              <button
-                type="submit"
-                data-evt="question_submit"
-                className="w-full bg-gradient-primary text-white py-4 rounded-xl font-semibold shadow-medium hover:shadow-strong transition-smooth hover:scale-[1.02] flex items-center justify-center space-x-2"
-              >
-                <Send className="w-5 h-5" />
-                <span>{currentTexts.submit}</span>
-              </button>
+                  {/* Industry and Team Size */}
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-base font-bold text-foreground mb-2">
+                        {currentTexts.industry}
+                      </label>
+                      <select
+                        value={formData.industry}
+                        onChange={(e) => handleInputChange('industry', e.target.value)}
+                        className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
+                      >
+                        {currentTexts.industries.map((industry, index) => (
+                          <option key={index} value={index === 0 ? '' : industry}>
+                            {industry}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-base font-bold text-foreground mb-2">
+                        {currentTexts.teamSize}
+                      </label>
+                      <select
+                        value={formData.teamSize}
+                        onChange={(e) => handleInputChange('teamSize', e.target.value)}
+                        className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
+                      >
+                        {currentTexts.teamSizes.map((size, index) => (
+                          <option key={index} value={index === 0 ? '' : size}>
+                            {size}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={handleNext}
+                    className="w-full bg-gradient-primary text-white py-4 rounded-xl font-semibold shadow-medium hover:shadow-strong transition-smooth hover:scale-[1.02]"
+                  >
+                    {currentTexts.next}
+                  </button>
+                </>
+              ) : (
+                <>
+                  {/* Repetitive Task */}
+                  <div>
+                    <label className="block text-base font-bold text-foreground mb-2">
+                      {currentTexts.repetitiveTask}
+                    </label>
+                    <input
+                      type="text"
+                      value={formData.repetitiveTask}
+                      onChange={(e) => handleInputChange('repetitiveTask', e.target.value)}
+                      className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth"
+                      placeholder="npr. kreiranje ponuda, unos računa..."
+                    />
+                  </div>
+
+                  {/* AI Usage */}
+                  <div>
+                    <label className="block text-base font-bold text-foreground mb-2">
+                      {currentTexts.aiUsage}
+                    </label>
+                    <div className="space-y-2">
+                      {currentTexts.aiUsageLevels.map((level, index) => (
+                        <label key={index} className="flex items-center space-x-3 cursor-pointer">
+                          <input
+                            type="radio"
+                            name="aiUsage"
+                            value={level}
+                            checked={formData.aiUsage === level}
+                            onChange={(e) => handleInputChange('aiUsage', e.target.value)}
+                            className="w-4 h-4 text-primary focus:ring-2 focus:ring-primary"
+                          />
+                          <span className="text-base font-bold text-foreground">{level}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Question */}
+                  <div>
+                    <label className="block text-base font-bold text-foreground mb-2">
+                      {currentTexts.question} *
+                    </label>
+                    <textarea
+                      required
+                      rows={3}
+                      value={formData.question}
+                      onChange={(e) => handleInputChange('question', e.target.value)}
+                      className="w-full px-4 py-3 bg-white/50 border border-white/30 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary transition-smooth resize-none"
+                      placeholder="Opišite svoj izazov ili pitanje..."
+                    />
+                  </div>
+
+                  {/* Checkboxes */}
+                  <div className="space-y-3">
+                    <label className="flex items-center space-x-3 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={formData.wantResponse}
+                        onChange={(e) => handleInputChange('wantResponse', e.target.checked)}
+                        className="w-4 h-4 text-primary focus:ring-2 focus:ring-primary rounded"
+                      />
+                      <span className="text-base font-bold text-foreground">{currentTexts.wantResponse}</span>
+                    </label>
+                    <label className="flex items-center space-x-3 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={formData.newsletter}
+                        onChange={(e) => handleInputChange('newsletter', e.target.checked)}
+                        className="w-4 h-4 text-primary focus:ring-2 focus:ring-primary rounded"
+                      />
+                      <span className="text-base font-bold text-foreground">{currentTexts.newsletter}</span>
+                    </label>
+                  </div>
+
+                  <div className="flex items-center justify-between space-x-4">
+                    <button
+                      type="button"
+                      onClick={handleBack}
+                      className="px-6 py-4 rounded-xl font-semibold text-foreground bg-white/50 hover:bg-white/70 transition-smooth"
+                    >
+                      {currentTexts.back}
+                    </button>
+                    <button
+                      type="submit"
+                      data-evt="question_submit"
+                      className="flex-1 bg-gradient-primary text-white py-4 rounded-xl font-semibold shadow-medium hover:shadow-strong transition-smooth hover:scale-[1.02] flex items-center justify-center space-x-2"
+                    >
+                      <Send className="w-5 h-5" />
+                      <span>{currentTexts.submit}</span>
+                    </button>
+                  </div>
+                </>
+              )}
             </form>
           </>
         ) : (


### PR DESCRIPTION
## Summary
- add navigation state and translations for two-step question modal
- show progress bar and separate form fields across steps

## Testing
- `npm run lint` (fails: 47 problems)
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68923bd0df3c8327b002fe25e3d38ccb