### PR TITLE
Improve article route error handling and bundle article data

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,5 +11,10 @@
       "src": "/api/(.*)",
       "dest": "api/index.ts"
     }
-  ]
+  ],
+  "functions": {
+    "api/index.ts": {
+      "includeFiles": "backend/articles/**"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- handle filesystem errors in article routes and return explicit responses
- resolve article path using working directory
- bundle `backend/articles` with the Vercel function

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint backend/src/routes/articles.ts` *(fails: 48 problems)*
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_6892ae7f5c9c8327b9a1bb7ab5a4adfe