### PR TITLE
Handle article fetch errors

### DIFF
--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -24,6 +24,7 @@ const BlogPost = () => {
   const [language, setLanguage] = useState<'hr' | 'en'>('hr');
   const [currentPost, setCurrentPost] = useState<Article | null>(null);
   const [relatedPosts, setRelatedPosts] = useState<Article[]>([]);
+  const [loadError, setLoadError] = useState(false);
 
   const sanitizedContent = useMemo(() => {
     if (!currentPost) return '';
@@ -66,8 +67,8 @@ const BlogPost = () => {
   }, [currentPost, language]);
 
   useEffect(() => {
-    fetch('/api/articles')
-      .then(r => r.json())
+    fetch("/api/articles")
+      .then(r => r.ok ? r.json() : Promise.reject(new Error(r.statusText)))
       .then((posts: Article[]) => {
         const post = posts.find(p => p.slug === slug);
         if (post) {
@@ -77,8 +78,30 @@ const BlogPost = () => {
             .slice(0, 3);
           setRelatedPosts(related);
         }
+      })
+      .catch(err => {
+        console.error(err);
+        setLoadError(true);
       });
   }, [slug, language]);
+
+  if (loadError) {
+    return (
+      <div className="min-h-screen bg-gradient-subtle flex items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-foreground mb-4">
+            {language === 'hr' ? 'Greška pri učitavanju članka' : 'Error loading article'}
+          </h1>
+          <button
+            onClick={() => navigate('/')}
+            className="bg-gradient-primary text-white px-6 py-3 rounded-xl font-medium"
+          >
+            {language === 'hr' ? 'Nazad na početnu' : 'Back to home'}
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   if (!currentPost) {
     return (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -224,24 +224,31 @@ const Index = () => {
       blogSectionSubtitle: 'Konkretni primjeri implementacije AI-ja u različitim industrijama',
       additionalArticles: 'Dodatni članci',
       filterBy: 'Filtriraj po kategoriji:',
-      allCategories: 'Sve kategorije'
+      allCategories: 'Sve kategorije',
+      loadError: 'Pogreška pri učitavanju članaka. Pokušajte ponovno kasnije.'
     },
     en: {
       blogSectionTitle: 'AI SOLUTIONS FOR YOUR INDUSTRY',
       blogSectionSubtitle: 'Concrete examples of AI implementation in different industries',
       additionalArticles: 'Additional Articles',
       filterBy: 'Filter by category:',
-      allCategories: 'All categories'
+      allCategories: 'All categories',
+      loadError: 'Failed to load articles. Please try again later.'
     }
   };
 
   const currentTexts = texts[language];
   const [posts, setPosts] = useState<Article[]>([]);
+  const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
-    fetch('/api/articles')
-      .then(r => r.json())
-      .then(setPosts);
+    fetch("/api/articles")
+      .then(r => r.ok ? r.json() : Promise.reject(new Error(r.statusText)))
+      .then(setPosts)
+      .catch(err => {
+        console.error(err);
+        setLoadError(true);
+      });
   }, []);
 
   const featuredPosts = posts.filter(post => post.featured);
@@ -272,16 +279,22 @@ const Index = () => {
       <section className="container mx-auto px-4 pb-16">
         <div className="max-w-7xl mx-auto">
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
-            {posts.map(post => (
-              <BlogCard
-                key={post.id}
-                title={post.title[language]}
-                excerpt={post.excerpt[language]}
-                slug={post.slug}
-                featured={post.featured}
-                thumbnail={post.thumbnail}
-              />
-            ))}
+            {loadError ? (
+              <p className="col-span-full text-center text-muted-foreground">
+                {currentTexts.loadError}
+              </p>
+            ) : (
+              posts.map(post => (
+                <BlogCard
+                  key={post.id}
+                  title={post.title[language]}
+                  excerpt={post.excerpt[language]}
+                  slug={post.slug}
+                  featured={post.featured}
+                  thumbnail={post.thumbnail}
+                />
+              ))
+            )}
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- handle non-OK responses when fetching articles
- show localized fallback messages when article requests fail

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, no-irregular-whitespace, @typescript-eslint/no-require-imports, etc.)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6892ae8c04c08327a971bfc8b7ec8aa4