### PR TITLE
feat: add intro audio play button

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { X, Headphones } from 'lucide-react';
 import Header from '@/components/Header';
 import AgentPanel from '@/components/AgentPanel';
@@ -41,38 +41,52 @@ const HeadphonesNotification = ({ language, isVisible, onClose }: {
   onClose: () => void; 
 }) => {
   const [showTypewriter, setShowTypewriter] = useState(false);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
 
   const texts = {
     hr: {
       mainText: "Kako bismo vam osigurali vrhunsko korisničko iskustvo, preporučujemo korištenje slušalica.",
       subText: "Na taj će način naš sustav besprijekorno prepoznati vaš glas, bez ometanja zbog povratnog zvuka iz zvučnika.",
-      closeButton: "ZATVORI"
+      closeButton: "ZATVORI",
+      playIntro: "POKRENI INTRO"
     },
     en: {
       mainText: "For the best user experience, we recommend using headphones.",
       subText: "This way our system will flawlessly recognize your voice, without interference from feedback sound from the speakers.",
-      closeButton: "CLOSE"
+      closeButton: "CLOSE",
+      playIntro: "PLAY INTRO"
     }
   };
 
   const currentTexts = texts[language];
 
   useEffect(() => {
+    if (isVisible && !audioRef.current) {
+      audioRef.current = new Audio(introAudio);
+      audioRef.current.muted = true;
+    }
     if (isVisible) {
-      // Pokretanje zvuka Intro.mp3
-      const audio = new Audio(introAudio);
-      audio.play().catch(err => {
-        console.log('Audio autoplay blocked:', err);
-      });
-
-      // Delay za typewriter efekt
       const timer = setTimeout(() => {
         setShowTypewriter(true);
       }, 500);
-
       return () => clearTimeout(timer);
     }
   }, [isVisible]);
+
+  const handlePlayIntro = () => {
+    if (!audioRef.current) {
+      audioRef.current = new Audio(introAudio);
+      audioRef.current.muted = true;
+    }
+    audioRef.current
+      .play()
+      .then(() => {
+        if (audioRef.current) audioRef.current.muted = false;
+      })
+      .catch(err => {
+        console.log('Audio playback failed:', err);
+      });
+  };
 
   if (!isVisible) return null;
 
@@ -151,6 +165,18 @@ const HeadphonesNotification = ({ language, isVisible, onClose }: {
               ))}
             </div>
           </div>
+
+          {/* Play Intro Button */}
+          <button
+            onClick={handlePlayIntro}
+            className="px-8 py-4 rounded-xl font-semibold text-white transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl text-lg mb-4"
+            style={{
+              background: 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)',
+              boxShadow: '0 10px 30px rgba(59,130,246,0.3)'
+            }}
+          >
+            {currentTexts.playIntro}
+          </button>
 
           {/* Close Button */}
           <button


### PR DESCRIPTION
## Summary
- avoid autoplay by removing automatic audio playback in headphone modal
- add Play Intro button to start intro audio after user interaction

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Parsing error: Unexpected token )... )*

------
https://chatgpt.com/codex/tasks/task_e_6892aea9d8608327a2e4cb17fefd23a0