### PR TITLE
Handle article list failures gracefully

### DIFF
--- a/backend/src/routes/articles.ts
+++ b/backend/src/routes/articles.ts
@@ -66,7 +66,7 @@ router.get("/", async (_req: Request, res: Response) => {
     res.json(data);
   } catch (err) {
     console.error("Failed to list articles", err);
-    res.status(500).json({ error: "failed_to_list_articles" });
+    return res.json([]);
   }
 });
 


### PR DESCRIPTION
## Summary
- Return an empty array when reading the article directory fails to keep the articles API responsive

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 40 errors, 8 warnings)
- `npx eslint backend/src/routes/articles.ts` (fails: Unexpected any)


------
https://chatgpt.com/codex/tasks/task_e_6892b23073f48327b26e48ddfa595959