### PR TITLE
serve frontend through express

### DIFF
--- a/backend/dist/server.js
+++ b/backend/dist/server.js
@@ -7,6 +7,7 @@ require("dotenv/config");
 const express_1 = __importDefault(require("express"));
 const cors_1 = __importDefault(require("cors"));
 const express_rate_limit_1 = __importDefault(require("express-rate-limit"));
+const path_1 = __importDefault(require("path"));
 const sendEmail_1 = __importDefault(require("./routes/sendEmail"));
 const agent_1 = __importDefault(require("./routes/agent"));
 const tts_1 = __importDefault(require("./routes/tts"));
@@ -38,6 +39,8 @@ app.use("/api/elevenlabs/summary", summary_1.default);
 app.use("/api/elevenlabs/sendEmail", sendEmail_1.default);
 app.use("/api/articles", articles_1.default);
 app.use("/api/question", question_1.default);
+app.use(express_1.default.static(path_1.default.resolve(__dirname, "../../dist")));
+app.get("*", (_req, res) => res.sendFile(path_1.default.resolve(__dirname, "../../dist/index.html")));
 /* 404 + error */
 app.use((_req, res) => res.status(404).json({ error: "not_found" }));
 app.use((err, _req, res, _next) => {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,6 +2,7 @@ import "dotenv/config";
 import express, { Request, Response, NextFunction } from "express";
 import cors from "cors";
 import rateLimit from "express-rate-limit";
+import path from "path";
 
 import sendEmailRouter from "./routes/sendEmail";
 import agentRouter from "./routes/agent";
@@ -39,6 +40,11 @@ app.use("/api/elevenlabs/summary", summaryRouter);
 app.use("/api/elevenlabs/sendEmail", sendEmailRouter);
 app.use("/api/articles", articlesRouter);
 app.use("/api/question", questionRouter);
+
+app.use(express.static(path.resolve(__dirname, "../../dist")));
+app.get("*", (_req: Request, res: Response) =>
+  res.sendFile(path.resolve(__dirname, "../../dist/index.html"))
+);
 
 /* 404 + error */
 app.use((_req: Request, res: Response) => res.status(404).json({ error: "not_found" }));


### PR DESCRIPTION
## Summary
- import `path` in backend server
- serve built frontend assets through Express static middleware and wildcard route

## Testing
- `npm run lint` *(fails: 48 problems)*
- `npx eslint backend/src/server.ts`
- `cd backend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68935b25dd3483278483a69bfcd6be07