### PR TITLE
chore: adjust Vercel build and routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "vercel-build": "cd backend && npm run build",
+    "vercel-build": "npm run build && cd backend && npm run build",
     "type-check": "tsc --noEmit",
     "dev:server": "cd backend && npm run dev"
   },

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
     {
       "src": "/api/(.*)",
       "dest": "api/index.ts"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/dist/$1"
     }
   ],
   "functions": {


### PR DESCRIPTION
## Summary
- build frontend before backend during Vercel deploy
- serve generated `dist` directory via Vercel routing

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*
- `npm run vercel-build`

------
https://chatgpt.com/codex/tasks/task_e_68935b2c5e6883278be3c4d49b9b00df