### PR TITLE
feat: serve frontend from root dist

### DIFF
--- a/backend/dist/server.js
+++ b/backend/dist/server.js
@@ -41,7 +41,7 @@ app.use("/api/articles", articles_1.default);
 app.use("/api/question", question_1.default);
 /* --- POČETAK SERVIRANJA FRONTENDA --- */
 // 1) Nađi dist iz korijena projekta
-const clientDistPath = path_1.default.resolve(process.cwd(), "dist");
+const clientDistPath = path_1.default.resolve(__dirname, "..", "..", "dist");
 // 2) Servaj statiku iz /home/conexa/neurobiz.me/dist
 app.use(express_1.default.static(clientDistPath));
 // 3) Sve nerelane GET zahtjeve (koji ne počinju s /api/) vraćaju index.html

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -44,7 +44,7 @@ app.use("/api/question", questionRouter);
 /* --- POČETAK SERVIRANJA FRONTENDA --- */
 
 // 1) Nađi dist iz korijena projekta
-const clientDistPath = path.resolve(process.cwd(), "dist");
+const clientDistPath = path.resolve(__dirname, "..", "..", "dist");
 
 // 2) Servaj statiku iz /home/conexa/neurobiz.me/dist
 app.use(express.static(clientDistPath));


### PR DESCRIPTION
## Summary
- resolve client dist path relative to repository root

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 38 errors, 8 warnings)*
- `npm run build`
- `cd backend && npm run build`
- `curl -s -o /tmp/index.html -w "%{http_code}\n" http://localhost:3000/`


------
https://chatgpt.com/codex/tasks/task_e_6893824bc1a483278332b88b78273296