### PR TITLE
Centralize dotenv configuration in backend

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import http from 'http';
 import app from './server';
 import { attachSttProxy } from './sttProxy';

--- a/backend/src/routes/question.ts
+++ b/backend/src/routes/question.ts
@@ -1,8 +1,5 @@
 import { Router, Request, Response } from "express";
 import nodemailer from "nodemailer";
-import dotenv from "dotenv";
-
-dotenv.config();
 
 interface QuestionBody {
   firstName: string;

--- a/backend/src/routes/sendEmail.ts
+++ b/backend/src/routes/sendEmail.ts
@@ -1,8 +1,5 @@
 import { Router, Request, Response } from "express";
 import nodemailer from "nodemailer";
-import dotenv from "dotenv";
-
-dotenv.config();
 
 const router = Router();
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,4 +1,3 @@
-import "dotenv/config";
 import express, { Request, Response, NextFunction } from "express";
 import cors from "cors";
 import rateLimit from "express-rate-limit";

--- a/backend/src/utils/llm.ts
+++ b/backend/src/utils/llm.ts
@@ -1,6 +1,5 @@
 // backend/src/utils/llm.ts
 
-import "dotenv/config";
 import OpenAI from "openai";
 
 const openai = new OpenAI({


### PR DESCRIPTION
## Summary
- load environment variables once via dotenv in backend entrypoint
- remove repeated dotenv imports/configs from server, utils, and routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 46 problems, 38 errors, 8 warnings)*
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_6893b4d4339c8327b0e68b08ad9e89da