### PR TITLE
refactor: lazy load nodemailer in email routes

### DIFF
--- a/backend/dist/routes/question.js
+++ b/backend/dist/routes/question.js
@@ -1,17 +1,48 @@
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = require("express");
-const nodemailer_1 = __importDefault(require("nodemailer"));
-const dotenv_1 = __importDefault(require("dotenv"));
-dotenv_1.default.config();
+let nodemailer;
 const router = (0, express_1.Router)();
 router.post("/", async (req, res) => {
     const body = req.body;
     try {
-        const transporter = nodemailer_1.default.createTransport({
+        if (!nodemailer) {
+            nodemailer = (await Promise.resolve().then(() => __importStar(require("nodemailer")))).default;
+        }
+        const transporter = nodemailer.createTransport({
             host: process.env.SMTP_HOST,
             port: Number(process.env.SMTP_PORT),
             secure: process.env.SMTP_SECURE === "true",

--- a/backend/dist/routes/sendEmail.js
+++ b/backend/dist/routes/sendEmail.js
@@ -1,12 +1,40 @@
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = require("express");
-const nodemailer_1 = __importDefault(require("nodemailer"));
-const dotenv_1 = __importDefault(require("dotenv"));
-dotenv_1.default.config();
+let nodemailer;
 const router = (0, express_1.Router)();
 /**
  * POST  /api/sendEmail
@@ -17,7 +45,10 @@ router.post("/", async (req, res) => {
     const { email, phone, painPoints = [], proposal } = req.body;
     try {
         /* 1) Nodemailer transporter */
-        const transporter = nodemailer_1.default.createTransport({
+        if (!nodemailer) {
+            nodemailer = (await Promise.resolve().then(() => __importStar(require("nodemailer")))).default;
+        }
+        const transporter = nodemailer.createTransport({
             host: process.env.SMTP_HOST,
             port: Number(process.env.SMTP_PORT),
             secure: process.env.SMTP_SECURE === "true", // 465

--- a/backend/src/routes/question.ts
+++ b/backend/src/routes/question.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from "express";
-import nodemailer from "nodemailer";
+
+let nodemailer: typeof import("nodemailer") | undefined;
 
 interface QuestionBody {
   firstName: string;
@@ -22,6 +23,9 @@ router.post("/", async (req: Request, res: Response) => {
   const body = req.body as QuestionBody;
 
   try {
+    if (!nodemailer) {
+      nodemailer = (await import("nodemailer")).default;
+    }
     const transporter = nodemailer.createTransport({
       host: process.env.SMTP_HOST,
       port: Number(process.env.SMTP_PORT),

--- a/backend/src/routes/sendEmail.ts
+++ b/backend/src/routes/sendEmail.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from "express";
-import nodemailer from "nodemailer";
+
+let nodemailer: typeof import("nodemailer") | undefined;
 
 const router = Router();
 
@@ -21,6 +22,9 @@ router.post("/", async (req: Request, res: Response) => {
 
   try {
     /* 1) Nodemailer transporter */
+    if (!nodemailer) {
+      nodemailer = (await import("nodemailer")).default;
+    }
     const transporter = nodemailer.createTransport({
       host: process.env.SMTP_HOST,
       port: Number(process.env.SMTP_PORT),


### PR DESCRIPTION
## Summary
- lazy-load nodemailer in question route
- lazy-load nodemailer in sendEmail route

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893ba188e4c83279ee60fb45e9830e6