### PR TITLE
Configure API proxy for Vite dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,8 +22,6 @@ export default defineConfig(({ mode }) => ({
       "/api": {
         target: "http://localhost:3000",
         changeOrigin: true,
-        secure: false,
-        ws: true,
       },
       "/stt": {
         target: "http://localhost:3000",


### PR DESCRIPTION
## Summary
- simplify `/api` proxy configuration to forward to the local backend

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 47 problems, 39 errors, 8 warnings)*
- `npm run type-check`
- `timeout 5 npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6893dcb660d48327950c4e99d8b1a4be