### PR TITLE
fix: adjust agent route response format

### DIFF
--- a/backend/dist/routes/agent.js
+++ b/backend/dist/routes/agent.js
@@ -20,13 +20,12 @@ router.post('/', async (req, res) => {
                 finishedAt: new Date().toISOString(),
             });
         }
-        res.status(200).json({ ok: true });
+        res.status(200).json({ success: true });
     }
     catch (err) {
         console.error(err);
         res.status(500).json({
-            error: 'Failed to update conversation',
-            message: err instanceof Error ? err.message : String(err),
+            error: err instanceof Error ? err.message : 'Unknown error',
         });
     }
 });

--- a/backend/src/routes/agent.ts
+++ b/backend/src/routes/agent.ts
@@ -30,12 +30,11 @@ router.post('/', async (req: Request, res: Response) => {
       });
     }
 
-    res.status(200).json({ ok: true });
+    res.status(200).json({ success: true });
   } catch (err) {
     console.error(err);
     res.status(500).json({
-      error: 'Failed to update conversation',
-      message: err instanceof Error ? err.message : String(err),
+      error: err instanceof Error ? err.message : 'Unknown error',
     });
   }
 });


### PR DESCRIPTION
## Summary
- ensure /api/agent returns a `success` flag instead of `ok`
- normalize error responses to only return an `error` message

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893f26bea68832782a5336e6c5799de