### PR TITLE
Refine footer links and agent behavior

### DIFF
--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -249,7 +249,7 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
       .map((m) => `${m.role === "user" ? "User" : "Agent"}: ${m.text}`)
       .join("\n");
     try {
-      const sumRes = await fetch("/api/summary", {
+      const sumRes = await fetch("/api/elevenlabs/summary", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -284,7 +284,7 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
       }
       const solutionText = `${sol.solutionText}\n${sol.cta}`;
       if (contactRef.current) {
-        await fetch("/api/sendEmail", {
+        await fetch("/api/elevenlabs/sendEmail", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -296,7 +296,6 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
         });
       }
       setSolutionTextState(solutionText);
-        setSolutionOpen(true);
         {
           const res = await fetch("/api/agent", {
             method: "POST",
@@ -332,6 +331,7 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
       const blob = await ttsRes.blob();
         const url = URL.createObjectURL(blob);
         new Audio(url).play();
+        setSolutionOpen(true);
         {
           const res = await fetch("/api/agent", {
             method: "POST",
@@ -463,7 +463,7 @@ const AgentPanel = ({ language }: AgentPanelProps) => {
     ws.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data as string);
-        if (data.audio_output?.data) {
+        if (data.audio_output?.data && !mutedRef.current) {
           setActiveSpeaker("agent");
           player.enqueueBase64(data.audio_output.data);
         }

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -249,12 +249,6 @@ const BlogPost = () => {
               >
                 {language === 'hr' ? 'Privatnost' : 'Privacy'}
               </a>
-              <a
-                href="/terms"
-                className="text-sm text-muted-foreground hover:text-primary transition-colors"
-              >
-                {language === 'hr' ? 'Uvjeti' : 'Terms'}
-              </a>
             </div>
           </div>
         </div>

--- a/src/pages/Book.tsx
+++ b/src/pages/Book.tsx
@@ -233,12 +233,6 @@ const Book = () => {
               >
                 {language === 'hr' ? 'Privatnost' : 'Privacy'}
               </a>
-              <a 
-                href="/terms" 
-                className="text-sm text-muted-foreground hover:text-primary transition-colors"
-              >
-                {language === 'hr' ? 'Uvjeti' : 'Terms'}
-              </a>
             </div>
           </div>
         </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,10 +1,9 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { X, Headphones } from 'lucide-react';
 import Header from '@/components/Header';
 import AgentPanel from '@/components/AgentPanel';
 import QuestionModal from '@/components/QuestionModal';
 import BlogCard from '@/components/BlogCard';
-import introAudio from '@/assets/Intro.mp3';
 
 interface Article {
   id: string;
@@ -41,30 +40,23 @@ const HeadphonesNotification = ({ language, isVisible, onClose }: {
   onClose: () => void; 
 }) => {
   const [showTypewriter, setShowTypewriter] = useState(false);
-  const audioRef = useRef<HTMLAudioElement | null>(null);
 
   const texts = {
     hr: {
       mainText: "Kako bismo vam osigurali vrhunsko korisničko iskustvo, preporučujemo korištenje slušalica.",
       subText: "Na taj će način naš sustav besprijekorno prepoznati vaš glas, bez ometanja zbog povratnog zvuka iz zvučnika.",
-      closeButton: "ZATVORI",
-      playIntro: "POKRENI INTRO"
+      closeButton: "ZATVORI"
     },
     en: {
       mainText: "For the best user experience, we recommend using headphones.",
       subText: "This way our system will flawlessly recognize your voice, without interference from feedback sound from the speakers.",
-      closeButton: "CLOSE",
-      playIntro: "PLAY INTRO"
+      closeButton: "CLOSE"
     }
   };
 
   const currentTexts = texts[language];
 
   useEffect(() => {
-    if (isVisible && !audioRef.current) {
-      audioRef.current = new Audio(introAudio);
-      audioRef.current.muted = true;
-    }
     if (isVisible) {
       const timer = setTimeout(() => {
         setShowTypewriter(true);
@@ -72,21 +64,6 @@ const HeadphonesNotification = ({ language, isVisible, onClose }: {
       return () => clearTimeout(timer);
     }
   }, [isVisible]);
-
-  const handlePlayIntro = () => {
-    if (!audioRef.current) {
-      audioRef.current = new Audio(introAudio);
-      audioRef.current.muted = true;
-    }
-    audioRef.current
-      .play()
-      .then(() => {
-        if (audioRef.current) audioRef.current.muted = false;
-      })
-      .catch(err => {
-        console.log('Audio playback failed:', err);
-      });
-  };
 
   if (!isVisible) return null;
 
@@ -165,18 +142,6 @@ const HeadphonesNotification = ({ language, isVisible, onClose }: {
               ))}
             </div>
           </div>
-
-          {/* Play Intro Button */}
-          <button
-            onClick={handlePlayIntro}
-            className="px-8 py-4 rounded-xl font-semibold text-white transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl text-lg mb-4"
-            style={{
-              background: 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)',
-              boxShadow: '0 10px 30px rgba(59,130,246,0.3)'
-            }}
-          >
-            {currentTexts.playIntro}
-          </button>
 
           {/* Close Button */}
           <button
@@ -348,17 +313,11 @@ const Index = () => {
               >
                 {language === 'hr' ? 'Privatnost' : 'Privacy'}
               </a>
-              <a 
-                href="/terms" 
-                className="text-sm text-muted-foreground hover:text-primary transition-colors"
-              >
-                {language === 'hr' ? 'Uvjeti' : 'Terms'}
-              </a>
-              <a 
-                href="/admin" 
+              <a
+                href="/admin"
                 className="text-xs text-muted-foreground/50 hover:text-primary transition-colors"
               >
-                admin
+                •
               </a>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Remove terms link and swap admin footer text for a subtle dot
- Fix conversation summary endpoint, email sending path, and mute handling in agent panel
- Delay showing solution until agent's closing audio begins and drop intro modal's play button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6894d613f3188327a6f0e6bfc079a3eb