### PR TITLE
Protect admin page behind password modal

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -35,8 +35,20 @@ export default function Admin() {
 
   function handleDelete(id: string) {
     if (!confirm("Delete transcript?")) return;
-    fetch(`/api/transcripts/${id}`, { method:"DELETE",headers:{ "x-admin-pass": pass } })
-      .then(()=> setRows(rows.filter(r=>r.id!==id)));
+    fetch(`/api/transcripts/${id}`, { method: "DELETE", headers: { "x-admin-pass": pass } })
+      .then(() => setRows(rows.filter(r => r.id !== id)));
+  }
+
+  if (!pass) {
+    return (
+      <PasswordModal
+        open
+        onSubmit={p => {
+          sessionStorage.setItem("adminPass", p);
+          setPass(p);
+        }}
+      />
+    );
   }
 
   return (
@@ -118,14 +130,6 @@ export default function Admin() {
       ) : (
         <Articles pass={pass} />
       )}
-
-      <PasswordModal
-        open={!pass}
-        onSubmit={p => {
-          sessionStorage.setItem("adminPass", p);
-          setPass(p);
-        }}
-      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show admin dashboard only after a password is supplied, preventing unauthorized users from viewing admin content

## Testing
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6894e3543ddc832794ee4140c03b401c